### PR TITLE
netaddr: initial go.mod, enforce import path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module inet.af/netaddr
+
+go 1.14

--- a/netaddr.go
+++ b/netaddr.go
@@ -5,7 +5,7 @@
 // Package netaddr contains an IP address type.
 //
 // This is a work in progress. See https://github.com/inetaf/netaddr for background.
-package netaddr
+package netaddr // import "inet.af/netaddr"
 
 import (
 	"errors"


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

Make module mode happy and enforce the correct import path, per email.

```
11:43 $ go build                    
go: cannot find main module, but found .git/config in /home/matt/src/inet.af/netaddr
        to create a module there, run:
        go mod init
```