### PR TITLE
netaddr: benchmarks for IPv6

### DIFF
--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -333,3 +333,27 @@ func BenchmarkIPv4_inline(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkStdIPv6(b *testing.B) {
+	b.ReportAllocs()
+	ips := []net.IP{}
+	for i := 0; i < b.N; i++ {
+		ip := net.ParseIP("2001:db8::1")
+		ips = ips[:0]
+		for i := 0; i < 100; i++ {
+			ips = append(ips, ip)
+		}
+	}
+}
+
+func BenchmarkIPv6(b *testing.B) {
+	b.ReportAllocs()
+	ips := []IP{}
+	for i := 0; i < b.N; i++ {
+		ip := mustIP("2001:db8::1")
+		ips = ips[:0]
+		for i := 0; i < 100; i++ {
+			ips = append(ips, ip)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

I had a brief discussion with @danderson about the ipv4i representation and was curious if clever tricks could be used to speed up IPv6 in the same fashion. Perhaps the use of the IPv6-mapped IPv4 representation or using some currently unallocated IPv6 bits for flags could be promising.

For now, here's some basic benchmarks for IPv6 as well. There's no easy constructor for IPv6 at the moment so I'm not sure this is a fair comparison.

```
✔ ~/src/inet.af/netaddr [mdl-bench-ipv6 L|✔] 
13:02 $ go test -bench=.
goos: linux
goarch: amd64
pkg: inet.af/netaddr
BenchmarkStdIPv4-24              9895953               114 ns/op              16 B/op          1 allocs/op
BenchmarkIPv4-24                12732474                89.4 ns/op             4 B/op          1 allocs/op
BenchmarkIPv4_inline-24         13502928                83.1 ns/op             0 B/op          0 allocs/op
BenchmarkStdIPv6-24              7302411               163 ns/op              16 B/op          1 allocs/op
BenchmarkIPv6-24                 2217591               552 ns/op             144 B/op          5 allocs/op
PASS
ok      inet.af/netaddr 6.840s
```