### PR TITLE
ci: use build matrix to test with multiple Go versions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,13 +10,16 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        go-version: [1.11, 1.12, 1.13, 1.14]
     runs-on: ubuntu-latest
 
     steps:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: ${{ go-version }}
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
Use a build matrix to test with Go 1.11, 1.12, 1.13 and Go 1.14.