### PR TITLE
ci: fix matrix property name after #22

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: ${{ go-version }}
+        go-version: ${{ matrix.go-version }}
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
Use the correct property matrix.go-version to fix the Github action and
use the Go version defined in the build matrix.