### PR TITLE
netaddr: add initial well-known IP addresses

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -97,6 +97,22 @@ func (ip v6AddrZone) String() string {
 	return (&net.IPAddr{IP: net.IP(ip.v6Addr[:]), Zone: ip.zone}).String()
 }
 
+// Well known IP addresses which are accessed only through exported functions,
+// so the linker can eliminate them if they are unused.
+var (
+	// ff02::1
+	ipv6LinkLocalAllNodes = IP{v6Addr{0: 0xff, 1: 0x02, 15: 0x01}}
+	// ::
+	ipv6Unspecified = IP{v6Addr{}}
+)
+
+// IPv6LinkLocalAllNodes returns the IPv6 link-local all nodes multicast
+// address ff02::1.
+func IPv6LinkLocalAllNodes() IP { return ipv6LinkLocalAllNodes }
+
+// IPv6Unspecified returns the IPv6 unspecified address ::.
+func IPv6Unspecified() IP { return ipv6Unspecified }
+
 // IPv4 returns the IP of the IPv4 address a.b.c.d.
 func IPv4(a, b, c, d uint8) IP {
 	return IP{v4Addr{a, b, c, d}}

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -302,6 +302,36 @@ func TestIPProperties(t *testing.T) {
 	}
 }
 
+func TestIPWellKnown(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   IP
+		std  net.IP
+	}{
+		{
+			name: "IPv6 link-local all nodes",
+			ip:   IPv6LinkLocalAllNodes(),
+			std:  net.IPv6linklocalallnodes,
+		},
+		{
+			name: "IPv6 unspecified",
+			ip:   IPv6Unspecified(),
+			std:  net.IPv6unspecified,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := tt.std.String()
+			got := tt.ip.String()
+
+			if got != want {
+				t.Fatalf("got %s, want %s", got, want)
+			}
+		})
+	}
+}
+
 func TestLess(t *testing.T) {
 	tests := []struct {
 		a, b IP


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

These are the only two "constants" I need at the moment. The standard library exposes a few more.

It'd be nice if these could be immutable but I think this is probably reasonable.