### PR TITLE
netaddr: fix #29, prevent integer underflow in IPPrefix.Contains

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -616,6 +616,10 @@ func (p IPPrefix) Contains(addr IP) bool {
 		if nn[i]&m != ip[i]&m {
 			return false
 		}
+		// Prevent integer underflow for masks of < /8.
+		if bits < 8 {
+			break
+		}
 		bits -= 8
 	}
 	return true

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -614,6 +614,17 @@ func TestIPPrefix(t *testing.T) {
 			},
 			contains: mustIPs("::1", "2001:db8::1"),
 		},
+		{
+			prefix: "2000::/3",
+			ip:     mustIP("2000::"),
+			bits:   3,
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("2000::"),
+				Mask: net.CIDRMask(3, 128),
+			},
+			contains:    mustIPs("2001:db8::1"),
+			notContains: mustIPs("fe80::1"),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.prefix, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

Fixes #29.