### PR TITLE
Avoid net.ResolveIPAddr in ParseIP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module inet.af/netaddr
 
 go 1.12
-
-require golang.org/x/perf v0.0.0-20200318175901-9c9101da8316 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module inet.af/netaddr
 
 go 1.12
+
+require golang.org/x/perf v0.0.0-20200318175901-9c9101da8316 // indirect

--- a/netaddr.go
+++ b/netaddr.go
@@ -136,9 +136,8 @@ func ParseIP(s string) (IP, error) {
 			// handle bad input with % at the end
 			return IP{}, fmt.Errorf("netaddr.ParseIP(%q): missing zone", s)
 		default:
-			// net.ParseIP can't deal with zoned scopes, lets split and try to parse the ip again
-			ipa.Zone = s[percent+1:]
-			s = s[:percent]
+			// net.ParseIP can't deal with zoned scopes, let's split and try to parse the IP again
+			s, ipa.Zone = s[:percent], s[percent+1:]
 			ipa.IP = net.ParseIP(s)
 			if ipa.IP == nil {
 				return IP{}, fmt.Errorf("netaddr.ParseIP(%q): unable to parse IP", s)

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -739,6 +739,10 @@ func TestParseIPPrefixError(t *testing.T) {
 			errstr: "no '/'",
 		},
 		{
+			prefix: "1.257.1.1/24",
+			errstr: "unable to parse IP",
+		},
+		{
 			prefix: "1.1.1.0/q",
 			errstr: "bad prefix",
 		},
@@ -786,6 +790,10 @@ func TestParseIPError(t *testing.T) {
 			ip:     "fe80::1cc0:3e8c:119f:c2e1%",
 			errstr: "missing zone",
 		},
+		{
+			ip:     "%eth0",
+			errstr: "missing IPv6 address",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.ip, func(t *testing.T) {
@@ -794,7 +802,7 @@ func TestParseIPError(t *testing.T) {
 				t.Fatal("no error")
 			}
 			if test.errstr == "" {
-				test.errstr = "unable to parse ip"
+				test.errstr = "unable to parse IP"
 			}
 			if got := err.Error(); !strings.Contains(got, test.errstr) {
 				t.Errorf("error is missing substring %q: %s", test.errstr, got)
@@ -915,5 +923,33 @@ func BenchmarkIPv4Contains(b *testing.B) {
 	ip := IPv4(192, 168, 1, 1)
 	for i := 0; i < b.N; i++ {
 		prefix.Contains(ip)
+	}
+}
+
+func BenchmarkParseIPv4(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ParseIP("192.168.1.1")
+	}
+}
+
+func BenchmarkParseIPv6(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ParseIP("fe80::1cc0:3e8c:119f:c2e1%ens18")
+	}
+}
+
+func BenchmarkStdParseIPv4(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		net.ParseIP("192.168.1.1")
+	}
+}
+
+func BenchmarkStdParseIPv6(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		net.ParseIP("fe80::1cc0:3e8c:119f:c2e1")
 	}
 }

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -739,10 +739,6 @@ func TestParseIPPrefixError(t *testing.T) {
 			errstr: "no '/'",
 		},
 		{
-			prefix: "1.257.1.1/24",
-			errstr: "lookup 1.257.1.1: no such host", // TODO: improve ParseIP error
-		},
-		{
 			prefix: "1.1.1.0/q",
 			errstr: "bad prefix",
 		},
@@ -764,6 +760,41 @@ func TestParseIPPrefixError(t *testing.T) {
 			_, err := ParseIPPrefix(test.prefix)
 			if err == nil {
 				t.Fatal("no error")
+			}
+			if got := err.Error(); !strings.Contains(got, test.errstr) {
+				t.Errorf("error is missing substring %q: %s", test.errstr, got)
+			}
+		})
+	}
+}
+
+func TestParseIPError(t *testing.T) {
+	tests := []struct {
+		ip     string
+		errstr string
+	}{
+		{
+			ip: "localhost",
+		},
+		{
+			ip: "500.0.0.1",
+		},
+		{
+			ip: "::gggg%eth0",
+		},
+		{
+			ip:     "fe80::1cc0:3e8c:119f:c2e1%",
+			errstr: "missing zone",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.ip, func(t *testing.T) {
+			_, err := ParseIP(test.ip)
+			if err == nil {
+				t.Fatal("no error")
+			}
+			if test.errstr == "" {
+				test.errstr = "unable to parse ip"
 			}
 			if got := err.Error(); !strings.Contains(got, test.errstr) {
 				t.Errorf("error is missing substring %q: %s", test.errstr, got)


### PR DESCRIPTION
ParseIP isn't documented to do dns resolution, it really shouldn't
anyway. A resolving function should be named something else, maybe even
ResolveIPAddr to match stdlib.

I originally was falling back to a combination of ParseIP for the ip and
ResolveIPAddr for the zone info, but according to RFC4007 splitting on
'%' is enough.

Signed-off-by: Manuel Mendez <mmendez534@gmail.com>

Fixes #32 