### PR TITLE
netaddr: fix IP.Prefix masking of zero IPs with non-multiple of 8 masks

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -445,7 +445,6 @@ func (ip IP) Prefix(bits uint8) (IPPrefix, error) {
 	n := bits
 	for i := 0; i < len(b); i++ {
 		if n >= 8 {
-			b[i] &= 0xff
 			n -= 8
 			continue
 		}

--- a/netaddr.go
+++ b/netaddr.go
@@ -450,7 +450,10 @@ func (ip IP) Prefix(bits uint8) (IPPrefix, error) {
 			continue
 		}
 
-		b[i] = ^byte(0xff >> n)
+		// Don't mask off all-zero bytes.
+		if b[i] != 0 {
+			b[i] = ^byte(0xff >> n)
+		}
 		n = 0
 	}
 

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -508,6 +508,12 @@ func TestIPPrefixMasking(t *testing.T) {
 				p:    mustIPPrefix(fmt.Sprintf("fe80::dead:beef:0:0%s/96", zone)),
 				ok:   true,
 			},
+			{
+				ip:   mustIP(fmt.Sprintf("::%s", zone)),
+				bits: 63,
+				p:    mustIPPrefix(fmt.Sprintf("::%s/63", zone)),
+				ok:   true,
+			},
 		}
 	}
 
@@ -544,6 +550,12 @@ func TestIPPrefixMasking(t *testing.T) {
 					ip:   mustIP("255.255.255.255"),
 					bits: 20,
 					p:    mustIPPrefix("255.255.240.0/20"),
+					ok:   true,
+				},
+				{
+					ip:   mustIP("0.0.0.0"),
+					bits: 15,
+					p:    mustIPPrefix("0.0.0.0/15"),
 					ok:   true,
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

See the following program: https://play.golang.org/p/qV5-lttn2TI
```
netaddr: 0.0.0.0/15: "0.0.0.0" == "0.254.0.0"? false
    net: 0.0.0.0/15: "0.0.0.0" == "0.0.0.0"? true

netaddr: ::/63: "::" == "0:0:0:fe::"? false
    net: ::/63: "::" == "::"? true
```

And before this modification, these test cases resulted in:

```
$ go test -count 1 .              
--- FAIL: TestIPPrefixMasking (0.00s)
    --- FAIL: TestIPPrefixMasking/IPv4 (0.00s)                                                   
        --- FAIL: TestIPPrefixMasking/IPv4/0.0.0.0/15 (0.00s)
            netaddr_test.go:593: prefix = "0.254.0.0/15", want "0.0.0.0/15"
    --- FAIL: TestIPPrefixMasking/IPv6 (0.00s)                                                   
        --- FAIL: TestIPPrefixMasking/IPv6/::/63 (0.00s)
            netaddr_test.go:593: prefix = "0:0:0:fe::/63", want "::/63"
    --- FAIL: TestIPPrefixMasking/IPv6_zone (0.00s)
        --- FAIL: TestIPPrefixMasking/IPv6_zone/::/63 (0.00s)
            netaddr_test.go:593: prefix = "0:0:0:fe::/63", want "::/63"
FAIL       
FAIL    inet.af/netaddr 0.004s
FAIL  
```