### PR TITLE
IP.Prefix: speed up by removing type switch and using fewer ops for masking.

### DIFF
--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -1153,6 +1153,11 @@ func BenchmarkIPPrefixMasking(b *testing.B) {
 			bits: 17,
 		},
 		{
+			name: "IPv4 /0",
+			ip:   IPv4(192, 0, 2, 0),
+			bits: 0,
+		},
+		{
 			name: "IPv6 /128",
 			ip:   mustIP("2001:db8::1"),
 			bits: 128,
@@ -1163,6 +1168,11 @@ func BenchmarkIPPrefixMasking(b *testing.B) {
 			bits: 65,
 		},
 		{
+			name: "IPv6 /0",
+			ip:   mustIP("2001:db8::1"),
+			bits: 0,
+		},
+		{
 			name: "IPv6 zone /128",
 			ip:   mustIP("2001:db8::1%eth0"),
 			bits: 128,
@@ -1171,6 +1181,11 @@ func BenchmarkIPPrefixMasking(b *testing.B) {
 			name: "IPv6 zone /65",
 			ip:   mustIP("2001:db8::1%eth0"),
 			bits: 65,
+		},
+		{
+			name: "IPv6 zone /0",
+			ip:   mustIP("2001:db8::1%eth0"),
+			bits: 0,
 		},
 	}
 

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -532,6 +532,7 @@ func TestIPPrefixMasking(t *testing.T) {
 			subtests: []subtest{
 				{
 					bits: 255,
+					ok: true,
 				},
 				{
 					bits: 16,


### PR DESCRIPTION
name                              old time/op    new time/op    delta
IPPrefixMasking/IPv4_/32-8          32.6ns ± 3%    29.2ns ± 3%  -10.47%  (p=0.000 n=17+20)
IPPrefixMasking/IPv4_/17-8          34.6ns ± 3%    32.8ns ± 4%   -5.23%  (p=0.000 n=20+19)
IPPrefixMasking/IPv6_/128-8         52.5ns ± 4%    43.0ns ± 2%  -18.10%  (p=0.000 n=20+19)
IPPrefixMasking/IPv6_/65-8          59.7ns ± 3%    47.4ns ± 2%  -20.66%  (p=0.000 n=20+19)
IPPrefixMasking/IPv6_zone_/128-8     103ns ± 4%      82ns ± 3%  -20.29%  (p=0.000 n=20+20)
IPPrefixMasking/IPv6_zone_/65-8      109ns ± 5%      93ns ± 3%  -14.08%  (p=0.000 n=20+20)

Signed-off-by: David Anderson <dave@natulte.net>