### PR TITLE
Don't panic on zero-value IP in Contains

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -727,8 +727,12 @@ func (p IPPrefix) IPNet() *net.IPNet {
 //
 // An IPv4 address will not match an IPv6 prefix.
 // A 4-in-6 IP will not match an IPv4 prefix.
+// A zero-value IP will not match any prefix.
 func (p IPPrefix) Contains(addr IP) bool {
 	var nn, ip []byte // these do not escape and so do not allocate
+	if addr.ipImpl == nil {
+		return false
+	}
 	if p.IP.is4() {
 		if !addr.is4() {
 			return false

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -773,7 +773,7 @@ func TestIPPrefix(t *testing.T) {
 				Mask: net.CIDRMask(0, 32),
 			},
 			contains:    mustIPs("192.168.0.1", "1.1.1.1"),
-			notContains: mustIPs("2001:db8::1"),
+			notContains: append(mustIPs("2001:db8::1"), IP{}),
 		},
 		{
 			prefix: "::/0",


### PR DESCRIPTION
Another reasonable behavior is to return `p.IP.ipImpl == nil`, considering a zero-value IP to be included in a zero-value Prefix.