### PR TITLE
introduce IPPrefix.Masked for zeroing masked address bits

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -681,6 +681,8 @@ func FromStdIPNet(std *net.IPNet) (prefix IPPrefix, ok bool) {
 // ParseIPPrefix parses s as an IP address prefix.
 // The string can be in the form "192.168.1.0/24" or "2001::db8::/32",
 // the CIDR notation defined in RFC 4632 and RFC 4291.
+//
+// Note that masked address bits are not zeroed. Use Masked for that.
 func ParseIPPrefix(s string) (IPPrefix, error) {
 	i := strings.IndexByte(s, '/')
 	if i < 0 {
@@ -706,6 +708,15 @@ func ParseIPPrefix(s string) (IPPrefix, error) {
 		IP:   ip,
 		Bits: uint8(bits),
 	}, nil
+}
+
+// Masked returns p in its canonical form, with bits of of p.IP not in p.Bits masked off.
+// If p is zero or otherwise invalid, Masked returns the zero value.
+func (p IPPrefix) Masked() IPPrefix {
+	if m, err := p.IP.Prefix(p.Bits); err == nil {
+		return m
+	}
+	return IPPrefix{}
 }
 
 // IPNet returns the net.IPNet representation of an IPPrefix.

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -711,6 +711,34 @@ func TestIs4In6(t *testing.T) {
 	}
 }
 
+func TestIPPrefixMasked(t *testing.T) {
+	tests := []struct {
+		prefix string
+		ip     IP
+	}{
+		{
+			prefix: "192.168.0.255/24",
+			ip:     mustIP("192.168.0.0"),
+		},
+		{
+			prefix: "2100::/3",
+			ip:     mustIP("2000::"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.prefix, func(t *testing.T) {
+			prefix, err := ParseIPPrefix(test.prefix)
+			if err != nil {
+				t.Fatal(err)
+			}
+			prefix = prefix.Masked()
+			if prefix.IP != test.ip {
+				t.Errorf("IP=%s, want %s", prefix.IP, test.ip)
+			}
+		})
+	}
+}
+
 func TestIPPrefix(t *testing.T) {
 	tests := []struct {
 		prefix      string


### PR DESCRIPTION
As suggested by @bradfitz in https://github.com/inetaf/netaddr/pull/46#issuecomment-671100081.