### PR TITLE
return error from ParseIP("127.6.0.0%0")

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -219,6 +219,9 @@ func ParseIP(s string) (IP, error) {
 			if ipa.IP == nil {
 				return IP{}, fmt.Errorf("netaddr.ParseIP(%q): unable to parse IP", s)
 			}
+			if !strings.Contains(s, ":") {
+				return IP{}, fmt.Errorf("netaddr.ParseIP(%q): cannot use scoped addressing zone with IPv4", s)
+			}
 		}
 	}
 

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -27,6 +27,7 @@ func TestParseString(t *testing.T) {
 		"::1",
 		"fe80::1cc0:3e8c:119f:c2e1%ens18",
 		"::ffff:c000:1234",
+		"::ffff:127.6.0.0%0",
 	}
 	for _, s := range tests {
 		t.Run(s, func(t *testing.T) {
@@ -46,6 +47,18 @@ func TestParseString(t *testing.T) {
 				t.Errorf("String = %q; want %q", back, s)
 			}
 		})
+	}
+}
+
+func TestParseIPBad(t *testing.T) {
+	tests := []string{
+		"127.6.0.0%0",
+	}
+	for _, test := range tests {
+		ip, err := ParseIP(test)
+		if err == nil {
+			t.Errorf("ParseIP(%q) should return error, parsed as %v", test, ip)
+		}
 	}
 }
 


### PR DESCRIPTION
Found by fuzzing netaddr.ParseIP against wgcfg.ParseIP.