### PR TITLE
Change representation to 20 bytes (32-bit) or 24 bytes (64-bit)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module inet.af/netaddr
 
 go 1.12
+
+require go4.org/intern v0.0.0-20201222181806-763bd24e33ab

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+go4.org/intern v0.0.0-20201222181806-763bd24e33ab h1:0V+gA+DKQSvINBzmFW6tc0Tz8/U7w3ZmhWP7Q+3wjhg=
+go4.org/intern v0.0.0-20201222181806-763bd24e33ab/go.mod h1:vLqJ+12kCw61iCWsPto0EOHhBS+o4rO5VIucbc9g2Cc=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222175341-b30ae309168e h1:ExUmGi0ZsQmiVo9giDQqXkr7vreeXPMkOGIusfsfbzI=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222175341-b30ae309168e/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=

--- a/netaddr.go
+++ b/netaddr.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"go4.org/intern"
 )
 
 // Simple constants copied to avoid importing math.
@@ -29,50 +31,43 @@ const (
 	maxUint16 = 1<<16 - 1
 )
 
+// o4 is the offset to the beginning of the IPv4 address within IP.a.
+const o4 = len(mapped4Prefix)
+
 // Sizes: (64-bit)
 //   net.IP:     24 byte slice header + {4, 16} = 28 to 40 bytes
 //   net.IPAddr: 40 byte slice header + {4, 16} = 44 to 56 bytes + zone length
-//   netaddr.IP: 16 byte interface + {4, 16, 24} = 20, 32, 40 bytes + zone length
+//   netaddr.IP: 24 bytes (zone is per-name singleton, shared across all users)
 
 // IP represents an IPv4 or IPv6 address (with or without a scoped
 // addressing zone), similar to Go's net.IP or net.IPAddr.
 //
 // Unlike net.IP or net.IPAddr, the netaddr.IP is a comparable value
 // type (it supports == and can be a map key) and is immutable.
-// Its memory representation ranges from 20 to 40 bytes, depending on
-// whether the underlying adddress is IPv4, IPv6, or IPv6 with a
-// zone. (This is smaller than the standard library's 28 to 56 bytes)
+// Its memory representation is 24 bytes in 64-bit machines (the same
+// size as a Go slice header) for both IPv4 and IPv6 address.
 type IP struct {
-	ipImpl
+	a [16]byte // IPv6 or IPv4-mapped IPv6 form of IPv4 addr
+
+	// z is a combination of the address family and the IPv6 zone.
+	//
+	// nil means invalid IP address (for the IP zero value).
+	// z4 means an IPv4 address.
+	// z6noz means an IPv6 address without a zone.
+	//
+	// Otherwise it's the interned zone name string.
+	z *intern.Value
 }
 
-// ipImpl is the interface representing either a v4addr, v6addr, v6ZoneAddr.
-type ipImpl interface {
-	is4() bool
-	is6() bool
-	is4in6() bool
-	as16() ip16
-	// prefix is the type-specific implementation of IP.Prefix.
-	prefix(uint8) (IPPrefix, error)
-	String() string
-}
+// z0, z4, and z6noz are sentinel IP.z values.
+// See the IP type's field docs.
+var (
+	z0    = (*intern.Value)(nil)
+	z4    = new(intern.Value)
+	z6noz = new(intern.Value)
+)
 
-type v4Addr [4]byte
-
-func (v4Addr) is4() bool    { return true }
-func (v4Addr) is6() bool    { return false }
-func (v4Addr) is4in6() bool { return false }
-func (ip v4Addr) as16() ip16 {
-	return ip16{
-		10: 0xff,
-		11: 0xff,
-		12: ip[0],
-		13: ip[1],
-		14: ip[2],
-		15: ip[3],
-	}
-}
-func (ip v4Addr) prefix(bits uint8) (IPPrefix, error) {
+func v4Prefix(ip [4]byte, bits uint8) (IPPrefix, error) {
 	if bits > 32 {
 		return IPPrefix{}, fmt.Errorf("netaddr: prefix length %d too large for IP address family", bits)
 	}
@@ -84,25 +79,18 @@ func (ip v4Addr) prefix(bits uint8) (IPPrefix, error) {
 	for i := skip; i < 4; i++ {
 		ip[i] = 0
 	}
-	return IPPrefix{IP{ip}, bits}, nil
+	return IPPrefix{IPv4(ip[0], ip[1], ip[2], ip[3]), bits}, nil
 }
-func (ip v4Addr) String() string { return fmt.Sprintf("%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]) }
 
 const (
 	// mapped4Prefix are the 12 leading bytes in a IPv4-mapped IPv6 address.
 	mapped4Prefix = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
-
-	// v6Loopback is the IPv6 loopback address.
-	v6Loopback = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"
 )
 
-type v6Addr [16]byte
+// v6Loopback is the IPv6 loopback address.
+var v6Loopback = [16]byte{15: 1}
 
-func (v6Addr) is4() bool       { return false }
-func (v6Addr) is6() bool       { return true }
-func (ip v6Addr) is4in6() bool { return string(ip[:len(mapped4Prefix)]) == mapped4Prefix }
-func (ip v6Addr) as16() ip16   { return ip16(ip) }
-func (ip v6Addr) prefix(bits uint8) (IPPrefix, error) {
+func v6Prefix(ip [16]byte, bits uint8) (IPPrefix, error) {
 	if bits > 128 {
 		return IPPrefix{}, fmt.Errorf("netaddr: prefix length %d too large for IP address family", bits)
 	}
@@ -115,72 +103,36 @@ func (ip v6Addr) prefix(bits uint8) (IPPrefix, error) {
 	for i := range b {
 		b[i] = 0
 	}
-	return IPPrefix{IP{ip}, bits}, nil
+	return IPPrefix{IPv6Raw(ip), bits}, nil
 }
-func (ip v6Addr) String() string {
-	// TODO: better implementation; don't jump through these hoops
-	// and pay these allocs just to share a bit of code with
-	// std. Just copy & modify it as needed.
-	if ip.is4in6() {
-		mod := ip
-		mod[10] = 0xfe // change to arbitrary byte that's not 0xff to hide it from Go
-		s := net.IP(mod[:]).String()
-		return strings.Replace(s, "::feff:", "::ffff:", 1)
-	}
-	return (&net.IPAddr{IP: net.IP(ip[:])}).String()
-}
-
-type v6AddrZone struct {
-	v6Addr
-	zone string
-}
-
-func (ip v6AddrZone) prefix(bits uint8) (IPPrefix, error) {
-	if bits > 128 {
-		return IPPrefix{}, fmt.Errorf("netaddr: prefix length %d too large for IP address family", bits)
-	}
-	skip, partial := int(bits/8), bits%8
-	if partial != 0 {
-		ip.v6Addr[skip] = ip.v6Addr[skip] & ^byte(0xff>>partial)
-		skip++
-	}
-	b := ip.v6Addr[skip:]
-	for i := range b {
-		b[i] = 0
-	}
-	return IPPrefix{IP{ip}, bits}, nil
-}
-func (ip v6AddrZone) String() string {
-	// TODO: better implementation
-	return (&net.IPAddr{IP: net.IP(ip.v6Addr[:]), Zone: ip.zone}).String()
-}
-
-// Well known IP addresses which are accessed only through exported functions,
-// so the linker can eliminate them if they are unused.
-var (
-	// ff02::1
-	ipv6LinkLocalAllNodes = IP{v6Addr{0: 0xff, 1: 0x02, 15: 0x01}}
-	// ::
-	ipv6Unspecified = IP{v6Addr{}}
-)
 
 // IPv6LinkLocalAllNodes returns the IPv6 link-local all nodes multicast
 // address ff02::1.
-func IPv6LinkLocalAllNodes() IP { return ipv6LinkLocalAllNodes }
+func IPv6LinkLocalAllNodes() IP { return IPv6Raw([16]byte{0: 0xff, 1: 0x02, 15: 0x01}) }
 
 // IPv6Unspecified returns the IPv6 unspecified address ::.
-func IPv6Unspecified() IP { return ipv6Unspecified }
+func IPv6Unspecified() IP { return IPv6Raw([16]byte{}) }
 
 // IPv4 returns the IP of the IPv4 address a.b.c.d.
 func IPv4(a, b, c, d uint8) IP {
-	return IP{v4Addr{a, b, c, d}}
+	return IP{
+		z: z4,
+		a: [16]byte{
+			10:     0xff,
+			11:     0xff,
+			o4 + 0: a,
+			o4 + 1: b,
+			o4 + 2: c,
+			o4 + 3: d,
+		},
+	}
 }
 
 // IPv6Raw returns the IPv6 address given by the bytes in addr,
 // without an implicit Unmap call to unmap any v6-mapped IPv4
 // address.
 func IPv6Raw(addr [16]byte) IP {
-	return IP{v6Addr(addr)}
+	return IP{a: addr, z: z6noz}
 }
 
 // IPFrom16 returns the IP address given by the bytes in addr,
@@ -189,10 +141,10 @@ func IPv6Raw(addr [16]byte) IP {
 // It is equivalent to calling IPv6Raw(addr).Unmap() but slightly more
 // efficient.
 func IPFrom16(addr [16]byte) IP {
-	if string(addr[:len(mapped4Prefix)]) == mapped4Prefix {
-		return IPv4(addr[12], addr[13], addr[14], addr[15])
+	if string(addr[:o4]) == mapped4Prefix {
+		return IPv4(addr[o4+0], addr[o4+1], addr[o4+2], addr[o4+3])
 	}
-	return IP{v6Addr(addr)}
+	return IPv6Raw(addr)
 }
 
 // ParseIP parses s as an IP address, returning the result. The string
@@ -224,17 +176,12 @@ func ParseIP(s string) (IP, error) {
 
 	if !strings.Contains(s, ":") {
 		if ip4 := ipa.IP.To4(); ip4 != nil {
-			var v4 v4Addr
-			copy(v4[:], ip4)
-			return IP{v4}, nil
+			return IPv4(ip4[0], ip4[1], ip4[2], ip4[3]), nil
 		}
 	}
-	var v6 v6Addr
-	copy(v6[:], ipa.IP.To16())
-	if ipa.Zone != "" {
-		return IP{v6AddrZone{v6, ipa.Zone}}, nil
-	}
-	return IP{v6}, nil
+	var a16 [16]byte
+	copy(a16[:], ipa.IP.To16())
+	return IPv6Raw(a16).WithZone(ipa.Zone), nil
 }
 
 // FromStdIP returns an IP from the standard library's IP type.
@@ -248,18 +195,16 @@ func ParseIP(s string) (IP, error) {
 // To convert a standard library IP without the implicit unmapping, use
 // FromStdIPRaw.
 func FromStdIP(std net.IP) (ip IP, ok bool) {
-	if len(std) == 16 && string(std[:len(mapped4Prefix)]) == mapped4Prefix {
-		std = std[len(mapped4Prefix):]
+	if len(std) == 16 && string(std[:o4]) == mapped4Prefix {
+		std = std[o4:]
 	}
 	switch len(std) {
 	case 4:
-		var a v4Addr
-		copy(a[:], std)
-		return IP{a}, true
+		return IPv4(std[0], std[1], std[2], std[3]), true
 	case 16:
-		var a v6Addr
+		var a [16]byte
 		copy(a[:], std)
-		return IP{a}, true
+		return IPFrom16(a), true
 	}
 	return IP{}, false
 }
@@ -271,13 +216,11 @@ func FromStdIP(std net.IP) (ip IP, ok bool) {
 func FromStdIPRaw(std net.IP) (ip IP, ok bool) {
 	switch len(std) {
 	case 4:
-		var a v4Addr
-		copy(a[:], std)
-		return IP{a}, true
+		return IPv4(std[0], std[1], std[2], std[3]), true
 	case 16:
-		var a v6Addr
+		var a [16]byte
 		copy(a[:], std)
-		return IP{a}, true
+		return IPv6Raw(a), true
 	}
 	return IP{}, false
 }
@@ -293,10 +236,10 @@ func (ip IP) IsZero() bool { return ip == IP{} }
 // For the zero value (see IP.IsZero), it returns 0.
 // For IP4-mapped IPv6 addresses, it returns 128.
 func (ip IP) BitLen() uint8 {
-	if ip.IsZero() {
+	switch ip.z {
+	case z0:
 		return 0
-	}
-	if ip.ipImpl.is4() {
+	case z4:
 		return 32
 	}
 	return 128
@@ -304,40 +247,27 @@ func (ip IP) BitLen() uint8 {
 
 // Zone returns ip's IPv6 scoped addressing zone, if any.
 func (ip IP) Zone() string {
-	if v6z, ok := ip.ipImpl.(v6AddrZone); ok {
-		return v6z.zone
+	if ip.z == nil {
+		return ""
 	}
-	return ""
+	zone, _ := ip.z.Get().(string)
+	return zone
 }
 
 // Compare returns an integer comparing two IPs.
 // The result will be 0 if ip==ip2, -1 if ip < ip2, and +1 if ip > ip2.
 // The definition of "less than" is the same as the IP.Less method.
 func (ip IP) Compare(ip2 IP) int {
-	a, b := ip, ip2
-	// Zero value sorts first.
-	if a.ipImpl == nil {
-		if b.ipImpl == nil {
-			return 0
-		}
+	f1, f2 := ip.BitLen(), ip2.BitLen()
+	if f1 < f2 {
 		return -1
 	}
-	if b.ipImpl == nil {
+	if f1 > f2 {
 		return 1
 	}
-
-	a4, b4 := a.Is4(), b.Is4()
-	if a4 != b4 {
-		if a4 {
-			return -1
-		}
-		return 1
-	}
-
-	aa, ba := a.As16(), b.As16()
-	c := bytes.Compare(aa[:], ba[:])
-	if c == 0 && !a4 {
-		za, zb := a.Zone(), b.Zone()
+	c := bytes.Compare(ip.a[:], ip2.a[:])
+	if c == 0 && ip.Is6() {
+		za, zb := ip.Zone(), ip2.Zone()
 		if za < zb {
 			c = -1
 		} else if za > zb {
@@ -357,17 +287,14 @@ func (ip IP) Less(ip2 IP) bool { return ip.Compare(ip2) == -1 }
 // The optional reuse IP provides memory to reuse.
 func (ip IP) ipZone(reuse net.IP) (stdIP net.IP, zone string) {
 	base := reuse[:0]
-	switch ip := ip.ipImpl.(type) {
-	case nil:
+	switch {
+	case ip.z == z0:
 		return nil, ""
-	case v4Addr:
-		return append(base, ip[0], ip[1], ip[2], ip[3]), ""
-	case v6Addr:
-		return append(base, ip[:]...), ""
-	case v6AddrZone:
-		return append(base, ip.v6Addr[:]...), ip.zone
+	case ip.Is4():
+		a4 := ip.As4()
+		return append(base, a4[:]...), ""
 	default:
-		panic("netaddr: unhandled ipImpl representation")
+		return append(base, ip.a[:]...), ip.Zone()
 	}
 }
 
@@ -383,27 +310,18 @@ func (ip IP) IPAddr() *net.IPAddr {
 //
 // It returns false for IP4-mapped IPv6 addresses. See IP.Unmap.
 func (ip IP) Is4() bool {
-	if ip.ipImpl == nil {
-		return false
-	}
-	return ip.ipImpl.is4()
+	return ip.z == z4
 }
 
 // Is4in6 reports whether ip is an IPv4-mapped IPv6 address.
 func (ip IP) Is4in6() bool {
-	if ip.ipImpl == nil {
-		return false
-	}
-	return ip.ipImpl.is4in6()
+	return ip.z != z0 && ip.z != z4 && string(ip.a[:o4]) == mapped4Prefix
 }
 
 // Is6 reports whether ip is an IPv6 address, including IPv4-mapped
 // IPv6 addresses.
 func (ip IP) Is6() bool {
-	if ip.ipImpl == nil {
-		return false
-	}
-	return ip.ipImpl.is6()
+	return ip.z != z0 && ip.z != z4
 }
 
 // Unmap returns ip with any IPv4-mapped IPv6 address prefix removed.
@@ -412,83 +330,61 @@ func (ip IP) Is6() bool {
 // returns the wrapped IPv4 address. Otherwise it returns ip, regardless
 // of its type.
 func (ip IP) Unmap() IP {
-	if !ip.Is4in6() {
-		return ip
+	if ip.Is4in6() {
+		ip.z = z4
 	}
-	a := ip.ipImpl.as16()
-	return IP{v4Addr{a[12], a[13], a[14], a[15]}}
+	return ip
 }
 
 // WithZone returns an IP that's the same as ip but with the provided
 // zone. If zone is empty, the zone is removed. If ip is an IPv4
 // address it's returned unchanged.
 func (ip IP) WithZone(zone string) IP {
-	if zone == "" {
-		if z, ok := ip.ipImpl.(v6AddrZone); ok {
-			return IP{z.v6Addr}
-		}
+	if !ip.Is6() {
 		return ip
 	}
-	switch ip := ip.ipImpl.(type) {
-	case v6Addr:
-		return IP{v6AddrZone{ip, zone}}
-	case v6AddrZone:
-		return IP{v6AddrZone{ip.v6Addr, zone}}
+	if zone == "" {
+		ip.z = z6noz
+		return ip
 	}
+	ip.z = intern.Get(zone)
 	return ip
 }
 
 // IsLinkLocalUnicast reports whether ip is a link-local unicast address.
 // If ip is the zero value, it will return false.
 func (ip IP) IsLinkLocalUnicast() bool {
-	// See: https://en.wikipedia.org/wiki/Link-local_address.
-	switch ip := ip.ipImpl.(type) {
-	case nil:
-		return false
-	case v4Addr:
-		return ip[0] == 169 && ip[1] == 254
-	case v6Addr:
-		return ip[0] == 0xfe && ip[1] == 0x80
-	case v6AddrZone:
-		return ip.v6Addr[0] == 0xfe && ip.v6Addr[1] == 0x80
-	default:
-		panic("netaddr: unhandled ipImpl representation")
+	if ip.Is4() {
+		return ip.a[o4+0] == 169 && ip.a[o4+1] == 254
 	}
+	if ip.Is6() {
+		return ip.a[0] == 0xfe && ip.a[1] == 0x80
+	}
+	return false // zero value
 }
 
 // IsLoopback reports whether ip is a loopback address. If ip is the zero value,
 // it will return false.
 func (ip IP) IsLoopback() bool {
-	switch ip := ip.ipImpl.(type) {
-	case nil:
-		return false
-	case v4Addr:
-		return ip[0] == 127
-	case v6Addr:
-		return string(ip[:len(v6Loopback)]) == v6Loopback
-	case v6AddrZone:
-		return string(ip.v6Addr[:len(v6Loopback)]) == v6Loopback
-	default:
-		panic("netaddr: unhandled ipImpl representation")
+	if ip.Is4() {
+		return ip.a[o4+0] == 127
 	}
+	if ip.Is6() {
+		return ip.a == v6Loopback
+	}
+	return false // zero value
 }
 
 // IsMulticast reports whether ip is a multicast address. If ip is the zero
 // value, it will return false.
 func (ip IP) IsMulticast() bool {
-	// See: https://en.wikipedia.org/wiki/Multicast_address.
-	switch ip := ip.ipImpl.(type) {
-	case nil:
-		return false
-	case v4Addr:
-		return ip[0]&0xf0 == 0xe0
-	case v6Addr:
-		return ip[0] == 0xff
-	case v6AddrZone:
-		return ip.v6Addr[0] == 0xff
-	default:
-		panic("netaddr: unhandled ipImpl representation")
+	if ip.Is4() {
+		return ip.a[o4+0]&0xf0 == 0xe0
 	}
+	if ip.Is6() {
+		return ip.a[0] == 0xff
+	}
+	return false // zero value
 }
 
 // Prefix applies a CIDR mask of leading bits to IP, producing an IPPrefix
@@ -496,12 +392,20 @@ func (ip IP) IsMulticast() bool {
 // a nil error are returned. If bits is larger than 32 for an IPv4 address or
 // 128 for an IPv6 address, an error is returned.
 func (ip IP) Prefix(bits uint8) (IPPrefix, error) {
-	if ip.ipImpl == nil {
+	if ip.z == z0 {
 		return IPPrefix{}, nil
 	}
-	// TODO: optimize this to return ip directly if it's already
-	// masked and to not allocate a new IP.ipImpl.
-	return ip.prefix(bits)
+	if ip.Is4() {
+		return v4Prefix(ip.As4(), bits)
+	}
+	ipp, err := v6Prefix(ip.a, bits)
+	if err != nil {
+		return IPPrefix{}, err
+	}
+	if z := ip.Zone(); z != "" {
+		ipp.IP = ipp.IP.WithZone(z)
+	}
+	return ipp, nil
 }
 
 // As16 returns the IP address in its 16 byte representation.
@@ -510,26 +414,18 @@ func (ip IP) Prefix(bits uint8) (IPPrefix, error) {
 // Zone method to get it).
 // The ip zero value returns all zeroes.
 func (ip IP) As16() [16]byte {
-	if ip.ipImpl == nil {
-		return [16]byte{}
-	}
-	return ip.ipImpl.as16()
+	return ip.a
 }
 
 // As4 returns an IPv4 or IPv4-in-IPv6 address in its 4 byte representation.
 // If ip is the IP zero value or an IPv6 address, As4 panics.
 // Note that 0.0.0.0 is not the zero value.
 func (ip IP) As4() [4]byte {
-	if ip.ipImpl == nil {
-		panic("As4 called on IP zero value")
+	if ip.z == z4 || ip.Is4in6() {
+		return [4]byte{ip.a[o4+0], ip.a[o4+1], ip.a[o4+2], ip.a[o4+3]}
 	}
-	switch v := ip.ipImpl.(type) {
-	case v4Addr:
-		return v
-	case v6Addr:
-		if v.is4in6() {
-			return [4]byte{v[12], v[13], v[14], v[15]}
-		}
+	if ip.z == z0 {
+		panic("As4 called on IP zero value")
 	}
 	panic("As4 called on IPv6 address")
 }
@@ -545,17 +441,24 @@ func (ip IP) As4() [4]byte {
 // Note that unlike the Go standard library's IP.String method,
 // IP4-mapped IPv6 addresses do not format as dotted decimals.
 func (ip IP) String() string {
-	if ip.ipImpl == nil {
+	if ip.z == z0 {
 		return "invalid IP"
 	}
-	return ip.ipImpl.String()
+	if ip.Is4() {
+		return fmt.Sprintf("%d.%d.%d.%d", ip.a[o4+0], ip.a[o4+1], ip.a[o4+2], ip.a[o4+3])
+	}
+	if ip.Is4in6() {
+		a4 := ip.As4()
+		return fmt.Sprintf("::ffff:%x:%x", uint16(a4[0])<<8|uint16(a4[1]), uint16(a4[2])<<8|uint16(a4[3]))
+	}
+	return (&net.IPAddr{IP: net.IP(ip.a[:]), Zone: ip.Zone()}).String()
 }
 
 // MarshalText implements the encoding.TextMarshaler interface,
 // The encoding is the same as returned by String, with one exception:
 // If ip is the zero value, the encoding is the empty string.
 func (ip IP) MarshalText() ([]byte, error) {
-	if ip.ipImpl == nil {
+	if ip.z == z0 {
 		return []byte(""), nil
 	}
 	return []byte(ip.String()), nil
@@ -565,7 +468,7 @@ func (ip IP) MarshalText() ([]byte, error) {
 // The IP address is expected in a form accepted by ParseIP.
 // It returns an error if *ip is not the IP zero value.
 func (ip *IP) UnmarshalText(text []byte) error {
-	if ip.ipImpl != nil {
+	if ip.z != z0 {
 		return errors.New("netaddr: refusing to Unmarshal into non-zero IP")
 	}
 	if len(text) == 0 {
@@ -609,8 +512,9 @@ func ParseIPPort(s string) (IPPort, error) {
 func (p IPPort) IsZero() bool { return p == IPPort{} }
 
 func (p IPPort) String() string {
-	if v4, ok := p.IP.ipImpl.(v4Addr); ok {
-		return fmt.Sprintf("%d.%d.%d.%d:%d", v4[0], v4[1], v4[2], v4[3], p.Port)
+	if p.IP.z == z4 {
+		a := p.IP.As4()
+		return fmt.Sprintf("%d.%d.%d.%d:%d", a[0], a[1], a[2], a[3], p.Port)
 	}
 	// TODO: this could be more efficient allocation-wise:
 	return net.JoinHostPort(p.IP.String(), strconv.Itoa(int(p.Port)))
@@ -624,16 +528,14 @@ func FromStdAddr(stdIP net.IP, port int, zone string) (_ IPPort, ok bool) {
 		return
 	}
 	ip = ip.Unmap()
-	ipp := IPPort{IP: ip, Port: uint16(port)}
 	if zone != "" {
-		v6a, is6 := ip.ipImpl.(v6Addr)
-		if !is6 {
+		if ip.Is4() {
+			ok = false
 			return
 		}
-		ipp.IP = IP{v6AddrZone{v6a, zone}}
-		return ipp, true
+		ip = ip.WithZone(zone)
 	}
-	return ipp, true
+	return IPPort{IP: ip, Port: uint16(port)}, true
 }
 
 var udpAddrPool = &sync.Pool{
@@ -782,23 +684,15 @@ func (p IPPrefix) IPNet() *net.IPNet {
 // A zero-value IP will not match any prefix.
 func (p IPPrefix) Contains(addr IP) bool {
 	var nn, ip []byte // these do not escape and so do not allocate
-	if addr.ipImpl == nil {
+	if f1, f2 := p.IP.BitLen(), addr.BitLen(); f1 == 0 || f2 == 0 || f1 != f2 {
 		return false
 	}
-	if p.IP.is4() {
-		if !addr.is4() {
-			return false
-		}
-		a1 := p.IP.ipImpl.(v4Addr)
-		a2 := addr.ipImpl.(v4Addr)
-		nn, ip = a1[:], a2[:]
+	if addr.Is4() {
+		nn = p.IP.a[o4:]
+		ip = addr.a[o4:]
 	} else {
-		if addr.is4() {
-			return false
-		}
-		a1 := p.IP.ipImpl.(v6Addr)
-		a2 := addr.ipImpl.(v6Addr)
-		nn, ip = a1[:], a2[:]
+		nn = p.IP.a[:]
+		ip = addr.a[:]
 	}
 	bits := p.Bits
 	for i := 0; bits > 0 && i < len(nn); i++ {


### PR DESCRIPTION
The new representation is basically:

```go
   type IP struct {
      addr [16]byte
      zone *zone // always the same pointer for a given zone string
   }
```

See '"The zone pointer" alternative' comment from
https://github.com/inetaf/netaddr/issues/53#issuecomment-747849869

Fixes #53