### PR TITLE
Test that Prior.Next and Next.Prior return same IP

### DIFF
--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -1790,11 +1790,13 @@ func TestIPNextPrior(t *testing.T) {
 	}{
 		{mustIP("10.0.0.1"), mustIP("10.0.0.2"), mustIP("10.0.0.0")},
 		{mustIP("10.0.0.255"), mustIP("10.0.1.0"), mustIP("10.0.0.254")},
+		{mustIP("127.0.0.1"), mustIP("127.0.0.2"), mustIP("127.0.0.0")},
 		{mustIP("254.255.255.255"), mustIP("255.0.0.0"), mustIP("254.255.255.254")},
 		{mustIP("255.255.255.255"), IP{}, mustIP("255.255.255.254")},
 		{mustIP("0.0.0.0"), mustIP("0.0.0.1"), IP{}},
 		{mustIP("::"), mustIP("::1"), IP{}},
 		{mustIP("::%x"), mustIP("::1%x"), IP{}},
+		{mustIP("::1"), mustIP("::2"), mustIP("::")},
 		{mustIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"), IP{}, mustIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe")},
 	}
 	for _, tt := range tests {
@@ -1804,6 +1806,12 @@ func TestIPNextPrior(t *testing.T) {
 		}
 		if gprior != tt.prior {
 			t.Errorf("IP(%v).Prior = %v; want %v", tt.ip, gprior, tt.prior)
+		}
+		if !tt.ip.Next().IsZero() && tt.ip.Next().Prior() != tt.ip {
+			t.Errorf("IP(%v).Next.Prior = %v; want %v", tt.ip, tt.ip.Next().Prior(), tt.ip)
+		}
+		if !tt.ip.Prior().IsZero() && tt.ip.Prior().Next() != tt.ip {
+			t.Errorf("IP(%v).Prior.Next = %v; want %v", tt.ip, tt.ip.Prior().Next(), tt.ip)
 		}
 	}
 }


### PR DESCRIPTION
Thanks for creating this library! This is something that I had wished existed before, so I'm glad you've taken the initiative to create this. I want to contribute to this effort and thought that adding some test cases would be a good way to go about it. If you have hints for other "good first issues" to tackle, I'd appreciate the direction!

As long as the Prior or Next address is valid, then doing the
inverse operation should get us the IP we started with.

This also adds a few test cases for localhost addresses.