### PR TITLE
add ParseIP test case

### DIFF
--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -30,6 +30,7 @@ func TestParseString(t *testing.T) {
 		"::ffff:c000:1234",
 		"::ffff:f077:ff",
 		"::ffff:c000:1234%zone",
+		"::f:ffff:0:0",
 	}
 	for _, s := range tests {
 		t.Run(s, func(t *testing.T) {


### PR DESCRIPTION
This passes on master but fails in #63 (at the moment).
This makes it interesting enough to keep.