### PR TITLE
add a fuzz function and corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+crashers
+suppressions
+netaddr-fuzz.zip

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "corpus"]
+	path = corpus
+	url = git@github.com:inetaf/netaddr-corpus.git

--- a/README.md
+++ b/README.md
@@ -18,3 +18,17 @@ See its docs: https://godoc.org/inet.af/netaddr
 * merges net.IPAddr and net.IP (which the Go net package is a little torn between for legacy reasons)
 * ...
 * TODO: finish this list
+
+## Testing
+
+In addition to regular Go tests, netaddr uses fuzzing.
+The corpus is stored separately, in a submodule,
+to minimize the impact on everyone else.
+
+To use:
+
+```
+$ git submodule update --init
+$ go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+$ go-fuzz-build && go-fuzz
+```

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,88 @@
+// Copyright 2020 The Inet.Af AUTHORS. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build gofuzz
+
+package netaddr
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+func Fuzz(b []byte) int {
+	s := string(b)
+
+	ip, err := ParseIP(s)
+	if err == nil {
+		s2 := ip.String()
+		// There's no guarantee that ip.String() will match s.
+		// But a round trip the other direction ought to succeed.
+		ip2, err := ParseIP(s2)
+		if err != nil {
+			panic(err)
+		}
+		if ip2 != ip {
+			fmt.Printf("ip=%#v ip2=%#v\n", ip, ip2)
+			panic("IP round trip identity failure")
+		}
+		if s2 != ip2.String() {
+			panic("IP String round trip identity failure")
+		}
+	}
+	// Check that we match the standard library's IP parser, modulo zones.
+	if !strings.Contains(s, "%") {
+		stdip := net.ParseIP(s)
+		if ip.IsZero() != (stdip == nil) {
+			fmt.Println("stdip=", stdip, "ip=", ip)
+			panic("net.ParseIP nil != ParseIP zero")
+		} else if !ip.IsZero() && !ip.Is4in6() && ip.String() != stdip.String() {
+			fmt.Println("ip=", ip, "stdip=", stdip)
+			panic("net.IP.String() != IP.String()")
+		}
+	}
+	// Check that .Next().Prior() and .Prior().Next() preserve the IP.
+	if !ip.IsZero() && !ip.Next().IsZero() && ip.Next().Prior() != ip {
+		fmt.Println("ip=", ip, ".next=", ip.Next(), ".next.prior=", ip.Next().Prior())
+		panic(".Next.Prior did not round trip")
+	}
+	if !ip.IsZero() && !ip.Prior().IsZero() && ip.Prior().Next() != ip {
+		fmt.Println("ip=", ip, ".prior=", ip.Prior(), ".prior.next=", ip.Prior().Next())
+		panic(".Prior.Next did not round trip")
+	}
+
+	port, err := ParseIPPort(s)
+	if err == nil {
+		s2 := port.String()
+		port2, err := ParseIPPort(s2)
+		if err != nil {
+			panic(err)
+		}
+		if port2 != port {
+			panic("IPPort round trip identity failure")
+		}
+		if port2.String() != s2 {
+			panic("IPPort String round trip identity failure")
+		}
+	}
+
+	ipp, err := ParseIPPrefix(s)
+	if err == nil {
+		s2 := ipp.String()
+		ipp2, err := ParseIPPrefix(s2)
+		if err != nil {
+			panic(err)
+		}
+		if ipp2 != ipp {
+			fmt.Printf("ipp=%#v ipp=%#v\n", ipp, ipp2)
+			panic("IPPrefix round trip identity failure")
+		}
+		if ipp2.String() != s2 {
+			panic("IPPrefix String round trip identity failure")
+		}
+	}
+
+	return 0
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module inet.af/netaddr
 
 go 1.12
 
-require go4.org/intern v0.0.0-20201223054237-ef8cbcb8edd7
+require (
+	github.com/dvyukov/go-fuzz v0.0.0-20201127111758-49e582c6c23d // indirect
+	go4.org/intern v0.0.0-20201223054237-ef8cbcb8edd7
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/dvyukov/go-fuzz v0.0.0-20201127111758-49e582c6c23d h1:e1v4V9Heb+c4xQCCONROFvlzNs6Gq8aRZRwt+WzSEqY=
+github.com/dvyukov/go-fuzz v0.0.0-20201127111758-49e582c6c23d/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 go4.org/intern v0.0.0-20201223054237-ef8cbcb8edd7 h1:yeDrXaQ3VRXbTN7lHj70DxW4LdPow83MVwPPRjpP70U=
 go4.org/intern v0.0.0-20201223054237-ef8cbcb8edd7/go.mod h1:vLqJ+12kCw61iCWsPto0EOHhBS+o4rO5VIucbc9g2Cc=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222175341-b30ae309168e h1:ExUmGi0ZsQmiVo9giDQqXkr7vreeXPMkOGIusfsfbzI=


### PR DESCRIPTION
I decided in this case to also commit the corpus, because it has been built up over several different implementations of netaddr, which means it has coverage hints that might be hard to discover given only one of those implementations.