### PR TITLE
Add a slow, but correct ParseIP as a reference implementation.

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -234,16 +234,16 @@ func FromStdIPRaw(std net.IP) (ip IP, ok bool) {
 // v4 returns the i'th byte of ip. If ip is not an IPv4, v4 returns
 // unspecified garbage.
 func (ip IP) v4(i uint8) uint8 {
-	return uint8(ip.lo>>((3-i)*8))
+	return uint8(ip.lo >> ((3 - i) * 8))
 }
 
 // v6 returns the i'th byte of ip. If ip is an IPv4 address, this
 // accesses the IPv4-mapped IPv6 address form of the IP.
 func (ip IP) v6(i uint8) uint8 {
 	if i >= 8 {
-		return uint8(ip.lo>>((15-i)*8))
+		return uint8(ip.lo >> ((15 - i) * 8))
 	} else {
-		return uint8(ip.hi>>((7-i)*8))
+		return uint8(ip.hi >> ((7 - i) * 8))
 	}
 }
 

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -17,186 +17,278 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"go4.org/intern"
 )
 
-func TestParseString(t *testing.T) {
-	tests := []string{
-		"1.2.3.4",
-		"0.0.0.0",
-		"::",
-		"::1",
-		"::1%zone",
-		"fe80::1cc0:3e8c:119f:c2e1%ens18",
-		"::ffff:c000:1234",
-		"::ffff:f077:ff",
-		"::ffff:c000:1234%zone",
-		"::f:ffff:0:0",
+func TestParseIP(t *testing.T) {
+	var validIPs = []struct {
+		in     string
+		ip     IP          // output of ParseIP()
+		ipaddr *net.IPAddr // output of .IPAddr()
+		str    string      // output of String(). If "", use in.
+	}{
+		// Basic zero IPv4 address.
+		{
+			in:     "0.0.0.0",
+			ip:     IP{0, 0xffff00000000, z4},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("0.0.0.0")},
+		},
+		// Basic non-zero IPv4 address.
+		{
+			in:     "192.168.140.255",
+			ip:     IP{0, 0xffffc0a88cff, z4},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("192.168.140.255")},
+		},
+		// IPv4 address in windows-style "print all the digits" form.
+		{
+			in:     "010.000.015.001",
+			ip:     IP{0, 0xffff0a000f01, z4},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("10.0.15.1")},
+			str:    "10.0.15.1",
+		},
+		// IPv4 address with a silly amount of leading zeros.
+		{
+			in:     "000001.00000002.00000003.000000004",
+			ip:     IP{0, 0xffff01020304, z4},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("1.2.3.4")},
+			str:    "1.2.3.4",
+		},
+		// Basic zero IPv6 address.
+		{
+			in:     "::",
+			ip:     IP{0, 0, z6noz},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("::")},
+		},
+		// Localhost IPv6.
+		{
+			in:     "::1",
+			ip:     IP{0, 1, z6noz},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("::1")},
+		},
+		// Fully expanded IPv6 address.
+		{
+			in:     "fd7a:115c:a1e0:ab12:4843:cd96:626b:430b",
+			ip:     IP{0xfd7a115ca1e0ab12, 0x4843cd96626b430b, z6noz},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("fd7a:115c:a1e0:ab12:4843:cd96:626b:430b")},
+		},
+		// IPv6 with elided fields in the middle.
+		{
+			in:     "fd7a:115c::626b:430b",
+			ip:     IP{0xfd7a115c00000000, 0x00000000626b430b, z6noz},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("fd7a:115c::626b:430b")},
+		},
+		// IPv6 with elided fields at the end.
+		{
+			in:     "fd7a:115c:a1e0:ab12:4843:cd96::",
+			ip:     IP{0xfd7a115ca1e0ab12, 0x4843cd9600000000, z6noz},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("fd7a:115c:a1e0:ab12:4843:cd96::")},
+		},
+		// IPv6 with the trailing 32 bits written as IPv4 dotted decimal.
+		{
+			in:     "::ffff:192.168.140.255",
+			ip:     IP{0, 0x0000ffffc0a88cff, z6noz},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("::ffff:192.168.140.255")},
+			str:    "::ffff:c0a8:8cff",
+		},
+		// IPv6 with a zone specifier.
+		{
+			in:     "fd7a:115c:a1e0:ab12:4843:cd96:626b:430b%eth0",
+			ip:     IP{0xfd7a115ca1e0ab12, 0x4843cd96626b430b, intern.Get("eth0")},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("fd7a:115c:a1e0:ab12:4843:cd96:626b:430b"), Zone: "eth0"},
+		},
+		// IPv6 with dotted decimal and zone specifier.
+		{
+			in:     "1:2::ffff:192.168.140.255%eth1",
+			ip:     IP{0x0001000200000000, 0x0000ffffc0a88cff, intern.Get("eth1")},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("1:2::ffff:192.168.140.255"), Zone: "eth1"},
+			str:    "1:2::ffff:c0a8:8cff%eth1",
+		},
 	}
-	for _, s := range tests {
-		t.Run(s, func(t *testing.T) {
-			ip, err := ParseIP(s)
+
+	for _, test := range validIPs {
+		t.Run(test.in, func(t *testing.T) {
+			got, err := ParseIP(test.in)
 			if err != nil {
 				t.Fatal(err)
 			}
-			ip2, err := ParseIP(s)
+			if got != test.ip {
+				t.Errorf("ParseIP(%q) got %#v, want %#v", test.in, got, test.ip)
+			}
+
+			// Check that ParseIP is a pure function.
+			got2, err := ParseIP(test.in)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if ip != ip2 {
-				t.Error("does not compare to self")
+			if got != got2 {
+				t.Errorf("ParseIP(%q) got 2 different results: %#v, %#v", test.in, got, got2)
 			}
-			back := ip.String()
-			if s != back {
-				t.Errorf("String = %q; want %q", back, s)
+
+			// Check that ParseIP(ip.String()) is the identity function.
+			s := got.String()
+			got3, err := ParseIP(s)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != got3 {
+				t.Errorf("ParseIP(%q) != ParseIP(ParseIP(%q).String()). Got %#v, want %#v", test.in, test.in, got3, got)
+			}
+
+			// Check that the slow-but-readable parser produces the same result.
+			slow, err := parseIPSlow(test.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != slow {
+				t.Errorf("ParseIP(%q) = %#v, parseIPSlow(%q) = %#v", test.in, got, test.in, slow)
+			}
+
+			// Check that IP converts to the correct stdlib value.
+			std := got.IPAddr()
+			std.IP = std.IP.To16() // Normalize encoding for comparison
+
+			if !reflect.DeepEqual(std, test.ipaddr) {
+				t.Errorf("ParseIP(%q).IPAddr() got %#v, want %#v", test.in, std, test.ipaddr)
+			}
+
+			// Check that the std IP converts back to the same value.
+			back, ok := FromStdIP(std.IP)
+			if !ok {
+				t.Fatalf("FromStdIP(ParseIP(%q).IPAddr()) failed", test.in)
+			}
+			// FromStdIP doesn't preserve the zone, so force it back by hand.
+			back.z = test.ip.z
+
+			if back != test.ip {
+				t.Errorf("FromStdIP(ParseIP(%q).IPAddr()) got %#v, want %#v", test.in, back, test.ip)
+			}
+
+			// Check that the parsed IP formats as expected.
+			s = got.String()
+			wants := test.str
+			if wants == "" {
+				wants = test.in
+			}
+			if s != wants {
+				t.Errorf("ParseIP(%q).String() got %q, want %q", test.in, s, wants)
+			}
+
+			// Check that MarshalText/UnmarshalText work similarly to
+			// ParseIP/String (see TestIPMarshalUnmarshal for
+			// marshal-specific behavior that's not common with
+			// ParseIP/String).
+			js := `"` + test.in + `"`
+			var jsgot IP
+			if err := json.Unmarshal([]byte(js), &jsgot); err != nil {
+				t.Fatal(err)
+			}
+			if jsgot != got {
+				t.Errorf("json.Unmarshal(%q) = %#v, want %#v", test.in, jsgot, got)
+			}
+			jsb, err := json.Marshal(jsgot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			jswant := `"` + wants + `"`
+			jsback := string(jsb)
+			if jsback != jswant {
+				t.Errorf("Marshal(Unmarshal(%q)) = %#v, want %#v", test.in, jsback, wants)
 			}
 		})
 	}
-}
 
-func TestParseIPv4Zone(t *testing.T) {
-	ip, err := ParseIP("1.2.3.4%zone")
-	if err == nil {
-		t.Fatalf("expected error parsing v4 w/ zone; got %v", ip)
-	}
-}
-
-func TestParseIPMatchesStd(t *testing.T) {
-	tests := []string{
+	var invalidIPs = []string{
+		// Empty string
+		"",
+		// Garbage non-IP
 		"bad",
-		"1.2.3.4",
-		"0.0.0.0",
-		"::",
-		"::1",
-		"000000192.0000168.00000.00001", // https://play.golang.org/p/06oxvudU5DT
-		"::ffff:1.2.3.4",
-		"::ff:1.2.3.4",
-		"ab:cd::1.2.3.4", // 1.2.3.4 syntax with non-4in6 prefix
+		// Single number. Some parsers accept this as an IPv4 address in
+		// big-endian uint32 form, but we don't.
+		"1234",
+		// IPv4 with a zone specifier
+		"1.2.3.4%eth0",
+		// IPv4 in dotted octal form
+		"0300.0250.0214.0377",
+		// IPv4 in dotted hex form
+		"0xc0.0xa8.0x8c.0xff",
+		// IPv4 in class B form
+		"192.168.12345",
+		// IPv4 in class A form
+		"192.1234567",
+		// IPv4 with a field bigger than 1b
+		"192.168.300.1",
+		// IPv4 with too many fields
+		"192.168.0.1.5.6",
+		// IPv6 with not enough fields
+		"1:2:3:4:5:6:7",
+		// IPv6 with too many fields
+		"1:2:3:4:5:6:7:8:9",
+		// IPv6 with 8 fields and a :: expander
+		"1:2:3:4::5:6:7:8",
+		// IPv6 with a field bigger than 2b
+		"fe801::1",
+		// IPv6 with non-hex values in field
+		"fe80:tail:scal:e::",
 	}
-	for _, s := range tests {
+
+	for _, s := range invalidIPs {
 		t.Run(s, func(t *testing.T) {
-			ip, err := ParseIP(s)
-			if err != nil {
-				if net.ParseIP(s) == nil {
-					// Both failed to parse, so they match. Good.
-					return
-				}
-				t.Fatalf("our ParseIP: %v", err)
+			got, err := ParseIP(s)
+			if err == nil {
+				t.Errorf("ParseIP(%q) = %#v, want error", s, got)
 			}
-			stdIP := net.ParseIP(s)
-			if stdIP == nil {
-				t.Fatalf("std ParseIP: %v", err)
+
+			slow, err := parseIPSlow(s)
+			if err == nil {
+				t.Errorf("parseIPSlow(%q) = %#v, want error", s, slow)
 			}
-			ipBack, ok := FromStdIP(stdIP)
-			if !ok {
-				t.Fatalf("didn't map back")
+
+			std := net.ParseIP(s)
+			if std != nil {
+				t.Errorf("net.ParseIP(%q) = %#v, want error", s, std)
 			}
-			if ipBack == ip {
-				// Match.
+
+			if s == "" {
+				// Don't test unmarshaling of "" here, do it in
+				// IPMarshalUnmarshal.
 				return
 			}
-			if ip.Is4in6() {
-				// Don't expect a match.
-				t.Logf("expected difference; we got %v; std can't distinguish 4-in-6 and got %v", ip, stdIP)
-				return
+			var jsgot IP
+			js := []byte(`"` + s + `"`)
+			if err := json.Unmarshal(js, &jsgot); err == nil {
+				t.Errorf("json.Unmarshal(%q) = %#v, want error", s, jsgot)
 			}
-			t.Fatalf("our parse %v != (std parse %v => back as %v)",
-				ip, stdIP, ipBack)
 		})
 	}
 }
 
 func TestIPMarshalUnmarshal(t *testing.T) {
-	tests := []string{
-		"",
-		"1.2.3.4",
-		"0.0.0.0",
-		"::",
-		"::1",
-		"fe80::1cc0:3e8c:119f:c2e1%ens18",
-		"::ffff:c000:1234",
+	// This only tests the cases where Marshal/Unmarshal diverges from
+	// the behavior of ParseIP/String. For the rest of the test cases,
+	// see TestParseIP above.
+	orig := `""`
+	var ip IP
+	if err := json.Unmarshal([]byte(orig), &ip); err != nil {
+		t.Fatalf("Unmarshal(%q) got error %v", orig, err)
+	}
+	if !ip.IsZero() {
+		t.Errorf("Unmarshal(%q) is not the zero IP", orig)
 	}
 
-	for _, s := range tests {
-		t.Run(s, func(t *testing.T) {
-			// Ensure that JSON  (and by extension, text) marshaling is
-			// sane by entering quoted input.
-			orig := `"` + s + `"`
-
-			var ip IP
-			if err := json.Unmarshal([]byte(orig), &ip); err != nil {
-				t.Fatalf("failed to unmarshal: %v", err)
-			}
-
-			ipb, err := json.Marshal(ip)
-			if err != nil {
-				t.Fatalf("failed to marshal: %v", err)
-			}
-
-			back := string(ipb)
-			if orig != back {
-				t.Errorf("Marshal = %q; want %q", back, orig)
-			}
-		})
+	jsb, err := json.Marshal(ip)
+	if err != nil {
+		t.Fatalf("Marshal(%v) got error %v", ip, err)
 	}
-}
+	back := string(jsb)
+	if back != orig {
+		t.Errorf("Marshal(Unmarshal(%q)) got %q, want %q", orig, back, orig)
+	}
 
-func TestIPUnmarshalTextNonZero(t *testing.T) {
-	ip := mustIP("::1")
-	if err := ip.UnmarshalText([]byte("xxx")); err == nil {
+	// Cannot unmarshal into a non-zero IP
+	ip = MustParseIP("1.2.3.4")
+	if err := ip.UnmarshalText([]byte("::1")); err == nil {
 		t.Fatal("unmarshaled into non-empty IP")
-	}
-}
-
-func TestIPIPAddr(t *testing.T) {
-	tests := []struct {
-		name string
-		ip   IP
-		ipa  *net.IPAddr
-	}{
-		{
-			name: "nil",
-			ipa:  &net.IPAddr{},
-		},
-		{
-			name: "v4Addr",
-			ip:   mustIP("192.0.2.1"),
-			ipa: &net.IPAddr{
-				IP: net.IPv4(192, 0, 2, 1).To4(),
-			},
-		},
-		{
-			name: "v6Addr",
-			ip:   mustIP("2001:db8::1"),
-			ipa: &net.IPAddr{
-				IP: net.ParseIP("2001:db8::1"),
-			},
-		},
-		{
-			name: "v6AddrZone",
-			ip:   mustIP("fe80::1%eth0"),
-			ipa: &net.IPAddr{
-				IP:   net.ParseIP("fe80::1"),
-				Zone: "eth0",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.ip.IPAddr()
-			if !reflect.DeepEqual(tt.ipa, got) {
-				t.Errorf("IPAddr = %+v; want %+v", got, tt.ipa)
-			}
-
-			if got.Zone == "" && tt.ip != (IP{}) {
-				back, ok := FromStdIP(got.IP)
-				if !ok {
-					t.Errorf("FromStdIP failed")
-				} else if back != tt.ip {
-					t.Errorf("FromStdIP = %v; want %v", back, tt.ip)
-				}
-			}
-		})
 	}
 }
 
@@ -1155,7 +1247,7 @@ func TestParseIPPort(t *testing.T) {
 		// TextMarshal and TextUnmarhsal mostly behave like
 		// ParseIPPort and String. Divergent behavior are handled in
 		// TestIPPortMarshalUnmarshal.
-		t.Run(test.in + "/Marshal", func(t *testing.T) {
+		t.Run(test.in+"/Marshal", func(t *testing.T) {
 			var got IPPort
 			jsin := `"` + test.in + `"`
 			err := json.Unmarshal([]byte(jsin), &got)
@@ -1180,8 +1272,8 @@ func TestParseIPPort(t *testing.T) {
 }
 
 func TestIPPortMarshalUnmarshal(t *testing.T) {
-	tests := []struct{
-		in string
+	tests := []struct {
+		in   string
 		want IPPort
 	}{
 		{"", IPPort{}},

--- a/slow_test.go
+++ b/slow_test.go
@@ -1,0 +1,185 @@
+// Copyright 2020 The Inet.Af AUTHORS. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package netaddr
+
+import (
+	"fmt"
+	"strings"
+	"strconv"
+)
+
+// zeros is a slice of eight stringified zeros. It's used in
+// parseIPSlow to construct slices of specific amounts of zero fields,
+// from 1 to 8.
+var zeros = []string{"0", "0", "0", "0", "0", "0", "0", "0"}
+
+// parseIPSlow is like ParseIP, but aims for readability above
+// speed. It's the reference implementation for correctness checking
+// and against which we measure optimized parsers.
+//
+// parseIPSlow understands the following forms of IP addresses:
+//  - Regular IPv4: 1.2.3.4
+//  - IPv4 with many leading zeros: 0000001.0000002.0000003.0000004
+//  - Regular IPv6: 1111:2222:3333:4444:5555:6666:7777:8888
+//  - IPv6 with many leading zeros: 00000001:0000002:0000003:0000004:0000005:0000006:0000007:0000008
+//  - IPv6 with zero blocks elided: 1111:2222::7777:8888
+//  - IPv6 with trailing 32 bits expressed as IPv4: 1111:2222:3333:4444:5555:6666:77.77.88.88
+//
+// It does not process the following IP address forms, which have been
+// varyingly accepted by some programs due to an under-specification
+// of the shapes of IPv4 addresses:
+//
+//  - IPv4 as a single 32-bit uint: 4660 (same as "1.2.3.4")
+//  - IPv4 with octal numbers: 0300.0250.0.01 (same as "192.168.0.1")
+//  - IPv4 with hex numbers: 0xc0.0xa8.0x0.0x1 (same as "192.168.0.1")
+//  - IPv4 in "class-B style": 1.2.52 (same as "1.2.3.4")
+//  - IPv4 in "class-A style": 1.564 (same as "1.2.3.4")
+func parseIPSlow(s string) (IP, error) {
+	// Identify and strip out the zone, if any. There should be 0 or 1
+	// '%' in the string.
+	var zone string
+	fs := strings.Split(s, "%")
+	switch len(fs) {
+	case 1:
+		// No zone, that's fine.
+	case 2:
+		s, zone = fs[0], fs[1]
+	default:
+		return IP{}, fmt.Errorf("netaddr.ParseIP(%q): too many zone specifiers", s) // TODO: less specific?
+	}
+
+	// IPv4 by itself is easy to do in a helper.
+	if strings.Count(s, ":") == 0 {
+		if zone != "" {
+			return IP{}, fmt.Errorf("netaddr.ParseIP(%q): IPv4 addresses cannot have a zone", s)
+		}
+		return parseIPv4Slow(s)
+	}
+
+	normal, err := normalizeIPv6Slow(s)
+	if err != nil {
+		return IP{}, err
+	}
+
+	// At this point, we've normalized the address back into 8 hex
+	// fields of 16 bits each. Parse that.
+	fs = strings.Split(normal, ":")
+	if len(fs) != 8 {
+		return IP{}, fmt.Errorf("netaddr.ParseIP(%q): wrong size address", s)
+	}
+	var ret [16]byte
+	for i, f := range fs {
+		a, b, err := parseWord(f)
+		if err != nil {
+			return IP{}, err
+		}
+		ret[i*2] = a
+		ret[i*2+1] = b
+	}
+
+	return IPv6Raw(ret).WithZone(zone), nil
+}
+
+// normalizeIPv6Slow expands s, which is assumed to be an IPv6
+// address, to its canonical text form.
+//
+// The canonical form of an IPv6 address is 8 colon-separated fields,
+// where each field should be a hex value from 0 to ffff. This
+// function does not verify the contents of each field.
+//
+// This function performs two transformations:
+//  - The last 32 bits of an IPv6 address may be represented in
+//    IPv4-style dotted quad form, as in 1:2:3:4:5:6:7.8.9.10. That
+//    address is transformed to its hex equivalent,
+//    e.g. 1:2:3:4:5:6:708:90a.
+//  - An address may contain one "::", which expands into as many
+//    16-bit blocks of zeros as needed to make the address its correct
+//    full size. For example, fe80::1:2 expands to fe80:0:0:0:0:0:1:2.
+//
+// Both short forms may be present in a single address,
+// e.g. fe80::1.2.3.4.
+func normalizeIPv6Slow(orig string) (string, error) {
+	s := orig
+
+	// Find and convert an IPv4 address in the final field, if any.
+	i := strings.LastIndex(s, ":")
+	if i == -1 {
+		return "", fmt.Errorf("netaddr.ParseIP(%q): invalid IP address", orig)
+	}
+	if strings.Contains(s[i+1:], ".") {
+		ip, err := parseIPv4Slow(s[i+1:])
+		if err != nil {
+			return "", err
+		}
+		s = fmt.Sprintf("%s:%02x%02x:%02x%02x", s[:i], ip.v4(0), ip.v4(1), ip.v4(2), ip.v4(3))
+	}
+
+	// Find and expand a ::, if any.
+	fs := strings.Split(s, "::")
+	switch len(fs) {
+	case 1:
+		// No ::, nothing to do.
+	case 2:
+		lhs, rhs := fs[0], fs[1]
+		// Found a ::, figure out how many zero blocks need to be
+		// inserted.
+		nblocks := strings.Count(lhs, ":")+strings.Count(rhs, ":")
+		if lhs != "" {
+			nblocks++
+		}
+		if rhs != "" {
+			nblocks++
+		}
+		if nblocks > 7 {
+			return "", fmt.Errorf("netaddr.ParseIP(%q): address too long", orig)
+		}
+		fs = nil
+		// Either side of the :: can be empty. We don't want empty
+		// fields to feature in the final normalized address.
+		if lhs != "" {
+			fs = append(fs, lhs)
+		}
+		fs = append(fs, zeros[:8-nblocks]...)
+		if rhs != "" {
+			fs = append(fs, rhs)
+		}
+		s = strings.Join(fs, ":")
+	default:
+		// Too many ::
+		return "", fmt.Errorf("netaddr.ParseIP(%q): invalid IP address", orig)
+	}
+
+	return s, nil
+}
+
+// parseIPv4Slow parses and returns an IPv4 address in dotted quad
+// form, e.g. "192.168.0.1". It is slow but easy to read, and the
+// reference implementation against which we compare faster
+// implementations for correctness.
+func parseIPv4Slow(s string) (IP, error) {
+	fs := strings.Split(s, ".")
+	if len(fs) != 4 {
+		return IP{}, fmt.Errorf("netaddr.ParseIP(%q): invalid IP address", s)
+	}
+	var ret [4]byte
+	for i := range ret {
+		val, err := strconv.ParseUint(fs[i], 10, 8)
+		if err != nil {
+			return IP{}, err
+		}
+		ret[i] = uint8(val)
+	}
+	return IPv4(ret[0], ret[1], ret[2], ret[3]), nil
+}
+
+// parseWord converts a 16-bit hex string into its corresponding
+// two-byte value.
+func parseWord(s string) (byte, byte, error) {
+	ret, err := strconv.ParseUint(s, 16, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	return uint8(ret >> 8), uint8(ret), nil
+}


### PR DESCRIPTION
The goal of this implementation is to be slow, but very readable, and a point of comparison for optimized implementations: faster implementations should behave exactly like parseIPSlow on the set of valid and invalid inputs, and the tests now enforce that in addition to parity with net.ParseIP.

Mostly this is useful if we implement behavior that diverges from net.ParseIP. By having a reference parser in netaddr itself, we can evolve the optimized/not-as-readable implementation in tandem with our own reference impl.