### PR TITLE
Speed up parseIPv4 3.3x.

### DIFF
--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -214,8 +214,14 @@ func TestParseIP(t *testing.T) {
 		"0xc0.0xa8.0x8c.0xff",
 		// IPv4 in class B form
 		"192.168.12345",
+		// IPv4 in class B form, with a small enough number to be
+		// parseable as a regular dotted decimal field.
+		"127.0.1",
 		// IPv4 in class A form
 		"192.1234567",
+		// IPv4 in class A form, with a small enough number to be
+		// parseable as a regular dotted decimal field.
+		"127.1",
 		// IPv4 with a field bigger than 1b
 		"192.168.300.1",
 		// IPv4 with too many fields


### PR DESCRIPTION
```
name            old time/op    new time/op    delta
ParseIPv4-8       63.2ns ± 4%    20.1ns ± 4%  -68.17%  (p=0.000 n=19+19)
StdParseIPv4-8    93.9ns ± 3%    93.3ns ± 3%     ~     (p=0.211 n=20+19)
```

Signed-off-by: David Anderson <dave@natulte.net>