### PR TITLE
Parse IPv6 without net.ParseIP, and make it faster.

### DIFF
--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -1441,31 +1441,38 @@ func BenchmarkIPv4Contains(b *testing.B) {
 	}
 }
 
-func BenchmarkParseIPv4(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		ParseIP("192.168.1.1")
+var parseBenchInputs = []struct {
+	name string
+	ip   string
+}{
+	{"v4", "192.168.1.1"},
+	{"v6", "fd7a:115c:a1e0:ab12:4843:cd96:626b:430b"},
+	{"v6_ellipsis", "fd7a:115c::626b:430b"},
+	{"v6_v4", "::ffff:192.168.140.255"},
+	{"v6_zone", "1:2::ffff:192.168.140.255%eth1"},
+}
+
+func BenchmarkParseIP(b *testing.B) {
+	z := intern.Get("eth1") // Pin to not benchmark the intern package
+	_ = z
+	for _, test := range parseBenchInputs {
+		b.Run(test.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				sinkIP, _ = ParseIP(test.ip)
+			}
+		})
 	}
 }
 
-func BenchmarkParseIPv6(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		ParseIP("fe80::1cc0:3e8c:119f:c2e1%ens18")
-	}
-}
-
-func BenchmarkStdParseIPv4(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		net.ParseIP("192.168.1.1")
-	}
-}
-
-func BenchmarkStdParseIPv6(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		net.ParseIP("fe80::1cc0:3e8c:119f:c2e1")
+func BenchmarkStdParseIP(b *testing.B) {
+	for _, test := range parseBenchInputs {
+		b.Run(test.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				sinkStdIP = net.ParseIP(test.ip)
+			}
+		})
 	}
 }
 
@@ -2318,9 +2325,12 @@ func TestPointLess(t *testing.T) {
 
 }
 
-var sinkIP IP
-var sinkIPPort IPPort
-var sinkIPPrefix IPPrefix
+var (
+	sinkIP       IP
+	sinkStdIP    net.IP
+	sinkIPPort   IPPort
+	sinkIPPrefix IPPrefix
+)
 
 func TestNoAllocs(t *testing.T) {
 	test := func(name string, f func()) {

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -84,6 +84,20 @@ func TestParseIP(t *testing.T) {
 			ip:     IP{0xfd7a115ca1e0ab12, 0x4843cd9600000000, z6noz},
 			ipaddr: &net.IPAddr{IP: net.ParseIP("fd7a:115c:a1e0:ab12:4843:cd96::")},
 		},
+		// IPv6 with single elided field at the end.
+		{
+			in:     "fd7a:115c:a1e0:ab12:4843:cd96:626b::",
+			ip:     IP{0xfd7a115ca1e0ab12, 0x4843cd96626b0000, z6noz},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("fd7a:115c:a1e0:ab12:4843:cd96:626b::")},
+			str:    "fd7a:115c:a1e0:ab12:4843:cd96:626b:0",
+		},
+		// IPv6 with single elided field in the middle.
+		{
+			in:     "fd7a:115c:a1e0::4843:cd96:626b:430b",
+			ip:     IP{0xfd7a115ca1e00000, 0x4843cd96626b430b, z6noz},
+			ipaddr: &net.IPAddr{IP: net.ParseIP("fd7a:115c:a1e0::4843:cd96:626b:430b")},
+			str:    "fd7a:115c:a1e0:0:4843:cd96:626b:430b",
+		},
 		// IPv6 with the trailing 32 bits written as IPv4 dotted decimal.
 		{
 			in:     "::ffff:192.168.140.255",
@@ -236,6 +250,8 @@ func TestParseIP(t *testing.T) {
 		"fe801::1",
 		// IPv6 with non-hex values in field
 		"fe80:tail:scal:e::",
+		// IPv6 with a zone delimiter but no zone.
+		"fe80::1%",
 	}
 
 	for _, s := range invalidIPs {
@@ -1129,7 +1145,7 @@ func TestParseIPPrefixError(t *testing.T) {
 		},
 		{
 			prefix: "1.257.1.1/24",
-			errstr: "unable to parse IP",
+			errstr: "value >255",
 		},
 		{
 			prefix: "1.1.1.0/q",
@@ -1191,14 +1207,16 @@ func TestParseIPError(t *testing.T) {
 			ip: "localhost",
 		},
 		{
-			ip: "500.0.0.1",
+			ip:     "500.0.0.1",
+			errstr: "field has value >255",
 		},
 		{
-			ip: "::gggg%eth0",
+			ip:     "::gggg%eth0",
+			errstr: "must have at least one digit",
 		},
 		{
 			ip:     "fe80::1cc0:3e8c:119f:c2e1%",
-			errstr: "missing zone",
+			errstr: "zone must be a non-empty string",
 		},
 		{
 			ip:     "%eth0",
@@ -1453,8 +1471,7 @@ var parseBenchInputs = []struct {
 }
 
 func BenchmarkParseIP(b *testing.B) {
-	z := intern.Get("eth1") // Pin to not benchmark the intern package
-	_ = z
+	sinkInternValue = intern.Get("eth1") // Pin to not benchmark the intern package
 	for _, test := range parseBenchInputs {
 		b.Run(test.name, func(b *testing.B) {
 			b.ReportAllocs()
@@ -2326,10 +2343,11 @@ func TestPointLess(t *testing.T) {
 }
 
 var (
-	sinkIP       IP
-	sinkStdIP    net.IP
-	sinkIPPort   IPPort
-	sinkIPPrefix IPPrefix
+	sinkIP          IP
+	sinkStdIP       net.IP
+	sinkIPPort      IPPort
+	sinkIPPrefix    IPPrefix
+	sinkInternValue *intern.Value
 )
 
 func TestNoAllocs(t *testing.T) {
@@ -2344,10 +2362,6 @@ func TestNoAllocs(t *testing.T) {
 	test("IPv4", func() { sinkIP = IPv4(1, 2, 3, 4) })
 	test("IPv6", func() { sinkIP = IPv6Raw([16]byte{}) })
 	test("ParseIP_4", func() { sinkIP, _ = ParseIP("1.2.3.4") })
-
-	// TODO: currently 4
-	// test("ParseIP_6", func() { sinkIP, _ = ParseIP("[::1]") })
-
-	// TODO: currently 1
-	// test("ParseIPPort", func() { sinkIPPort, _ = ParseIPPort("[::1]:1234") })
+	test("ParseIP_6", func() { sinkIP, _ = ParseIP("::1") })
+	test("ParseIPPort", func() { sinkIPPort, _ = ParseIPPort("[::1]:1234") })
 }

--- a/slow_test.go
+++ b/slow_test.go
@@ -46,6 +46,9 @@ func parseIPSlow(s string) (IP, error) {
 		// No zone, that's fine.
 	case 2:
 		s, zone = fs[0], fs[1]
+		if zone == "" {
+			return IP{}, fmt.Errorf("netaddr.ParseIP(%q): no zone after zone specifier", s)
+		}
 	default:
 		return IP{}, fmt.Errorf("netaddr.ParseIP(%q): too many zone specifiers", s) // TODO: less specific?
 	}


### PR DESCRIPTION
    With this change, netaddr is no longer dependent on net.ParseIP for its
    ParseIP implementation. It's also 2-4x faster than net.ParseIP and
    allocation-free, except for v6+zone addresses which are still slower and
    require 1 allocation.

```    
    name                      old time/op    new time/op    delta
    ParseIP/v4-8                22.0ns ± 2%    24.5ns ± 1%   +11.46%  (p=0.016 n=5+4)
    ParseIP/v6-8                 169ns ± 2%      91ns ± 2%   -45.97%  (p=0.008 n=5+5)
    ParseIP/v6_ellipsis-8        140ns ± 2%      68ns ± 5%   -51.32%  (p=0.008 n=5+5)
    ParseIP/v6_v4-8              216ns ± 1%      71ns ± 1%   -67.19%  (p=0.008 n=5+5)
    ParseIP/v6_zone-8            526ns ± 1%     222ns ± 1%   -57.89%  (p=0.008 n=5+5)
    StdParseIP/v4-8             94.5ns ± 2%    89.0ns ± 1%    -5.78%  (p=0.008 n=5+5)
    StdParseIP/v6-8              150ns ± 1%     158ns ± 2%    +5.21%  (p=0.008 n=5+5)
    StdParseIP/v6_ellipsis-8     116ns ± 3%     125ns ± 2%    +7.59%  (p=0.008 n=5+5)
    StdParseIP/v6_v4-8           190ns ± 1%     183ns ± 2%    -3.89%  (p=0.008 n=5+5)
    StdParseIP/v6_zone-8         138ns ± 2%     133ns ± 2%    -3.20%  (p=0.024 n=5+5)
    
    name                      old alloc/op   new alloc/op   delta
    ParseIP/v4-8                 0.00B          0.00B           ~     (all equal)
    ParseIP/v6-8                 16.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
    ParseIP/v6_ellipsis-8        16.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
    ParseIP/v6_v4-8              32.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
    ParseIP/v6_zone-8            64.0B ± 0%     16.0B ± 0%   -75.00%  (p=0.008 n=5+5)
    StdParseIP/v4-8              16.0B ± 0%     16.0B ± 0%      ~     (all equal)
    StdParseIP/v6-8              16.0B ± 0%     16.0B ± 0%      ~     (all equal)
    StdParseIP/v6_ellipsis-8     16.0B ± 0%     16.0B ± 0%      ~     (all equal)
    StdParseIP/v6_v4-8           32.0B ± 0%     32.0B ± 0%      ~     (all equal)
    StdParseIP/v6_zone-8         16.0B ± 0%     16.0B ± 0%      ~     (all equal)
    
    name                      old allocs/op  new allocs/op  delta
    ParseIP/v4-8                  0.00           0.00           ~     (all equal)
    ParseIP/v6-8                  1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
    ParseIP/v6_ellipsis-8         1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
    ParseIP/v6_v4-8               2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
    ParseIP/v6_zone-8             4.00 ± 0%      1.00 ± 0%   -75.00%  (p=0.008 n=5+5)
    StdParseIP/v4-8               1.00 ± 0%      1.00 ± 0%      ~     (all equal)
    StdParseIP/v6-8               1.00 ± 0%      1.00 ± 0%      ~     (all equal)
    StdParseIP/v6_ellipsis-8      1.00 ± 0%      1.00 ± 0%      ~     (all equal)
    StdParseIP/v6_v4-8            2.00 ± 0%      2.00 ± 0%      ~     (all equal)
    StdParseIP/v6_zone-8          1.00 ± 0%      1.00 ± 0%      ~     (all equal)
```