### PR TITLE
fix IPPrefix.Contains

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -802,10 +802,11 @@ func (p IPPrefix) Contains(addr IP) bool {
 		return false
 	}
 	if addr.Is4() {
-		return uint32(addr.lo)&mask4(p.Bits) == uint32(p.IP.lo)
+		m := mask4(p.Bits)
+		return uint32(addr.lo)&m == uint32(p.IP.lo)&m
 	} else {
 		mhi, mlo := mask6(p.Bits)
-		return addr.hi&mhi == p.IP.hi && addr.lo&mlo == p.IP.lo
+		return addr.hi&mhi == p.IP.hi&mhi && addr.lo&mlo == p.IP.lo&mlo
 	}
 }
 

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -1228,14 +1228,10 @@ func TestUDPAddrAllocs(t *testing.T) {
 	}
 }
 
-func mustIP(s string) IP {
-	ip, err := ParseIP(s)
-	if err != nil {
-		panic(err)
-	}
-
-	return ip
-}
+var (
+	mustIP       = MustParseIP
+	mustIPPrefix = MustParseIPPrefix
+)
 
 func mustIPs(strs ...string) []IP {
 	var res []IP
@@ -1243,15 +1239,6 @@ func mustIPs(strs ...string) []IP {
 		res = append(res, mustIP(s))
 	}
 	return res
-}
-
-func mustIPPrefix(s string) IPPrefix {
-	p, err := ParseIPPrefix(s)
-	if err != nil {
-		panic(err)
-	}
-
-	return p
 }
 
 func BenchmarkStdIPv4(b *testing.B) {
@@ -1908,6 +1895,34 @@ func TestIPBitLen(t *testing.T) {
 		got := tt.ip.BitLen()
 		if got != tt.want {
 			t.Errorf("BitLen(%v) = %d; want %d", tt.ip, got, tt.want)
+		}
+	}
+}
+
+func TestIPPrefixContains(t *testing.T) {
+	tests := []struct {
+		ipp  IPPrefix
+		ip   IP
+		want bool
+	}{
+		{mustIPPrefix("9.8.7.6/0"), mustIP("9.8.7.6"), true},
+		{mustIPPrefix("9.8.7.6/16"), mustIP("9.8.7.6"), true},
+		{mustIPPrefix("9.8.7.6/16"), mustIP("9.8.6.4"), true},
+		{mustIPPrefix("9.8.7.6/16"), mustIP("9.9.7.6"), false},
+		{mustIPPrefix("9.8.7.6/32"), mustIP("9.8.7.6"), true},
+		{mustIPPrefix("9.8.7.6/32"), mustIP("9.8.7.7"), false},
+		{mustIPPrefix("9.8.7.6/32"), mustIP("9.8.7.7"), false},
+		{mustIPPrefix("::1/0"), mustIP("::1"), true},
+		{mustIPPrefix("::1/0"), mustIP("::2"), true},
+		{mustIPPrefix("::1/127"), mustIP("::1"), true},
+		{mustIPPrefix("::1/127"), mustIP("::2"), false},
+		{mustIPPrefix("::1/128"), mustIP("::1"), true},
+		{mustIPPrefix("::1/127"), mustIP("::2"), false},
+	}
+	for _, tt := range tests {
+		got := tt.ipp.Contains(tt.ip)
+		if got != tt.want {
+			t.Errorf("(%v).Contains(%v) = %v want %v", tt.ipp, tt.ip, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
The mask needs to be applied on both sides.
Regression introduced in 4eb479db13f8b816537f38c664776b193c7a86ec
and caught far away in Tailscale's tests.

Signed-off-by: Josh Bleecher Snyder <josharian@gmail.com>