### PR TITLE
Optimizes parseIPv4

### DIFF
--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -222,6 +222,12 @@ func TestParseIP(t *testing.T) {
 		"1234",
 		// IPv4 with a zone specifier
 		"1.2.3.4%eth0",
+		// IPv4 field must have at least one digit
+		".1.2.3",
+		"1.2.3.",
+		"1..2.3",
+		// IPv4 address too long
+		"1.2.3.4.5",
 		// IPv4 in dotted octal form
 		"0300.0250.0214.0377",
 		// IPv4 in dotted hex form
@@ -236,7 +242,7 @@ func TestParseIP(t *testing.T) {
 		// IPv4 in class A form, with a small enough number to be
 		// parseable as a regular dotted decimal field.
 		"127.1",
-		// IPv4 with a field bigger than 1b
+		// IPv4 field has value >255
 		"192.168.300.1",
 		// IPv4 with too many fields
 		"192.168.0.1.5.6",


### PR DESCRIPTION
```
benchmark                              old ns/op     new ns/op     delta
BenchmarkParseIP/v4-8                  22.9          18.4          -19.65%
BenchmarkParseIP/v6-8                  77.4          77.9          +0.65%
BenchmarkParseIP/v6_ellipsis-8         56.5          55.5          -1.77%
BenchmarkParseIP/v6_v4-8               63.8          58.1          -8.93%
BenchmarkParseIP/v6_zone-8             144           140           -2.78%
BenchmarkParseIPPort/v4-8              42.5          37.8          -11.06%
BenchmarkParseIPPort/v6-8              99.6          100           +0.40%
BenchmarkParseIPPort/v6_ellipsis-8     80.2          79.2          -1.25%
BenchmarkParseIPPort/v6_v4-8           86.9          81.8          -5.87%
BenchmarkParseIPPort/v6_zone-8         176           169           -3.98%
```

Following recent @danderson twitter storm here is my take that is a bit faster. 
Not a big deal, just for your amusement. Probably could be improved by reading multiple bytes at once or vectorizing (not sure if possible) but at the cost if readability which definitely makes no sense in a grand scheme of things.