### PR TITLE
Remove dependency on stdlib for ParseIPPort, make faster.

### DIFF
--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -1548,7 +1548,7 @@ func BenchmarkIPPrefixMasking(b *testing.B) {
 func BenchmarkParseIPPort(b *testing.B) {
 	for _, test := range parseBenchInputs {
 		var ipp string
-		if strings.HasPrefix(test.ip, "v6") {
+		if strings.HasPrefix(test.name, "v6") {
 			ipp = fmt.Sprintf("[%s]:1234", test.ip)
 		} else {
 			ipp = fmt.Sprintf("%s:1234", test.ip)

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -1249,6 +1249,7 @@ func TestParseIPPort(t *testing.T) {
 		{in: "1.1.1.1:123456", wantErr: true},
 		{in: "1.1.1.1:-123", wantErr: true},
 		{in: "[::1]:1234", want: IPPort{mustIP("::1"), 1234}},
+		{in: "[1.2.3.4]:1234", wantErr: true},
 		{in: "fe80::1:1234", wantErr: true},
 		{in: ":0", wantErr: true}, // if we need to parse this form, there should be a separate function that explicitly allows it
 	}


### PR DESCRIPTION
Makes long strings parse a little faster, because unlike net.SplitHostPort, we
can entirely ignore the contents of the ip and port portions, and let our subsequent
parser deal with errors there.

```
ParseIPPort/v4-8             56.5ns ± 3%    57.4ns ± 3%     ~     (p=0.421 n=5+5)
ParseIPPort/v6-8              143ns ± 2%     117ns ± 4%  -18.44%  (p=0.008 n=5+5)
ParseIPPort/v6_ellipsis-8     112ns ± 5%     100ns ± 1%  -10.68%  (p=0.008 n=5+5)
ParseIPPort/v6_v4-8           143ns ± 5%     139ns ± 1%     ~     (p=0.175 n=5+5)
ParseIPPort/v6_zone-8         272ns ± 1%     256ns ± 1%   -5.96%  (p=0.008 n=5+5)
```

Signed-off-by: David Anderson <dave@natulte.net>