### PR TITLE
Implement IP.String without relying on the stdlib.

### DIFF
--- a/inlining_test.go
+++ b/inlining_test.go
@@ -62,6 +62,7 @@ func TestInlining(t *testing.T) {
 		"IP.lo",
 		"IP.v4",
 		"IP.v6",
+		"IP.v6u16",
 		"IP.withInternedZone",
 		"IPPort.IsZero",
 		"IPPort.MarshalText",
@@ -86,6 +87,8 @@ func TestInlining(t *testing.T) {
 		"uint128.bitSet",
 		"uint128.or",
 		"uint128.xor",
+		"appendDecimal",
+		"appendHex",
 	} {
 		if !got[want] {
 			t.Errorf("%q is no longer inlinable", want)


### PR DESCRIPTION
Makes String faster, and only makes 1 heap allocation for most IP shapes.
(v6+zone where the IP is the longest it can be can still cause extra allocs
to append the zone string)

IP.String is faster than net.IP.String for all cases, except IPv4-mapped IPv6,
because the stdlib prints it as an IPv4 and we print it as an IPv6, and so
need to do more work to format it.

```
name                    old time/op    new time/op    delta
IPString/v4-8              267ns ± 1%      53ns ± 3%  -80.03%  (p=0.000 n=9+10)
IPString/v6-8              268ns ± 1%     130ns ± 3%  -51.62%  (p=0.000 n=9+10)
IPString/v6_ellipsis-8     198ns ± 3%     117ns ± 3%  -40.74%  (p=0.000 n=10+10)
IPString/v6_v4-8           306ns ± 3%     121ns ± 2%  -60.32%  (p=0.000 n=9+10)
IPString/v6_zone-8         302ns ± 3%     135ns ± 1%  -55.24%  (p=0.000 n=10+10)

name                    old alloc/op   new alloc/op   delta
IPString/v4-8              16.0B ± 0%     16.0B ± 0%     ~     (all equal)
IPString/v6-8              48.0B ± 0%     48.0B ± 0%     ~     (all equal)
IPString/v6_ellipsis-8     32.0B ± 0%     32.0B ± 0%     ~     (all equal)
IPString/v6_v4-8           20.0B ± 0%     16.0B ± 0%  -20.00%  (p=0.000 n=10+10)
IPString/v6_zone-8         64.0B ± 0%     32.0B ± 0%  -50.00%  (p=0.000 n=10+10)

name                    old allocs/op  new allocs/op  delta
IPString/v4-8               1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IPString/v6-8               1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IPString/v6_ellipsis-8      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
IPString/v6_v4-8            3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
IPString/v6_zone-8          2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=10+10)
```

Signed-off-by: David Anderson <dave@natulte.net>