### PR TITLE
optimize IPRange.Prefix[es], common prefix length, etc

### DIFF
--- a/inlining_test.go
+++ b/inlining_test.go
@@ -70,6 +70,8 @@ func TestInlining(t *testing.T) {
 		"IPPrefix.IsZero",
 		"IPPrefix.Masked",
 		"IPPrefix.String",
+		"IPRange.prefixFrom128AndBits",
+		"IPRange.prefixFrom128AndBits-fm",
 		"IPv4",
 		"IPv6LinkLocalAllNodes",
 		"IPv6Unspecified",
@@ -82,6 +84,8 @@ func TestInlining(t *testing.T) {
 		"mask6",
 		"uint128.and",
 		"uint128.bitSet",
+		"uint128.or",
+		"uint128.xor",
 	} {
 		if !got[want] {
 			t.Errorf("%q is no longer inlinable", want)

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -2232,6 +2232,16 @@ func TestIPRangePrefix(t *testing.T) {
 	}
 }
 
+func BenchmarkIPRangePrefix(b *testing.B) {
+	b.ReportAllocs()
+	r := IPRange{mustIP("10.0.0.0"), mustIP("10.0.0.255")}
+	for i := 0; i < b.N; i++ {
+		if _, ok := r.Prefix(); !ok {
+			b.Fatal("expected a prefix")
+		}
+	}
+}
+
 func TestIPNextPrior(t *testing.T) {
 	tests := []struct {
 		ip    IP


### PR DESCRIPTION
More to go, but this is a start...

```
    name             old time/op    new time/op    delta
    IPRangePrefix-4     822ns ± 7%     149ns ± 5%  -81.87%  (p=0.008 n=5+5)
    
    name             old alloc/op   new alloc/op   delta
    IPRangePrefix-4     0.00B          0.00B          ~     (all equal)
    
    name             old allocs/op  new allocs/op  delta
    IPRangePrefix-4      0.00           0.00          ~     (all equal)
```

Before:

```
      flat  flat%   sum%        cum   cum%
     2.49s 57.11% 57.11%      2.49s 57.11%  inet.af/netaddr.uint128.bitSet
     1.30s 29.82% 86.93%      3.79s 86.93%  inet.af/netaddr.comparePrefixes
     0.15s  3.44% 90.37%      0.15s  3.44%  inet.af/netaddr.IP.IsZero (inline)
     0.10s  2.29% 92.66%      0.10s  2.29%  inet.af/netaddr.IPRange.prefixMaker.func1
     0.06s  1.38% 94.04%      0.07s  1.61%  inet.af/netaddr.IPRange.prefixMaker
     0.05s  1.15% 95.18%      4.29s 98.39%  inet.af/netaddr.IPRange.Prefix
     0.05s  1.15% 96.33%      0.28s  6.42%  inet.af/netaddr.IPRange.Valid
     0.03s  0.69% 97.02%      0.05s  1.15%  inet.af/netaddr.IP.Compare
     0.02s  0.46% 97.48%      0.07s  1.61%  inet.af/netaddr.IP.Less (inline)
     0.01s  0.23% 97.71%      4.30s 98.62%  inet.af/netaddr.BenchmarkIPRangePrefix
```

After:

```
          flat  flat%   sum%        cum   cum%
        1270ms 34.51% 34.51%     2100ms 57.07%  inet.af/netaddr.comparePrefixes
         470ms 12.77% 47.28%      870ms 23.64%  inet.af/netaddr.IPRange.Valid
         410ms 11.14% 58.42%     3560ms 96.74%  inet.af/netaddr.IPRange.Prefix
         320ms  8.70% 67.12%      320ms  8.70%  inet.af/netaddr.u64CommonPrefixLen
         250ms  6.79% 73.91%      570ms 15.49%  inet.af/netaddr.uint128.commonPrefixLen
         170ms  4.62% 78.53%      330ms  8.97%  inet.af/netaddr.IP.Compare
         160ms  4.35% 82.88%      180ms  4.89%  inet.af/netaddr.IPRange.prefixFrom128AndBits (inline)
         110ms  2.99% 85.87%      110ms  2.99%  inet.af/netaddr.uint128.and (inline)
          90ms  2.45% 88.32%     3650ms 99.18%  inet.af/netaddr.BenchmarkIPRangePrefix
          80ms  2.17% 90.49%       80ms  2.17%  inet.af/netaddr.uint128.xor (inline)
```