### PR TITLE
make IPRange.Valid report false when zones differ

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -1110,8 +1110,9 @@ func (p IPPrefix) lastIP() IP {
 // range.
 //
 // To be valid, the From and To values be non-zero, have matching
-// address families (IPv4 vs IPv6), and From must be less than or
-// equal to To. An invalid range may be ignored.
+// address families (IPv4 vs IPv6), be in the same IPv6 zone (if any),
+// and From must be less than or equal to To.
+// An invalid range may be ignored.
 type IPRange struct {
 	// From is the initial IP address in the range.
 	From IP
@@ -1161,11 +1162,11 @@ func (r IPRange) String() string {
 }
 
 // Valid reports whether r.From and r.To are both non-zero and obey
-// the documented requirements: address families match, and From is
-// less than or equal to To.
+// the documented requirements: address families match, same IPv6
+// zone, and From is less than or equal to To.
 func (r IPRange) Valid() bool {
-	return !r.From.IsZero() && !r.To.IsZero() &&
-		r.From.Is4() == r.To.Is4() &&
+	return !r.From.IsZero() &&
+		r.From.z == r.To.z &&
 		!r.To.Less(r.From)
 }
 

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -2202,6 +2202,28 @@ func TestIPRangeOverlaps(t *testing.T) {
 	}
 }
 
+func TestIPRangeValid(t *testing.T) {
+	tests := []struct {
+		r    IPRange
+		want bool
+	}{
+		{IPRange{mustIP("10.0.0.0"), mustIP("10.0.0.255")}, true},
+		{IPRange{mustIP("::1"), mustIP("::2")}, true},
+		{IPRange{mustIP("::1%foo"), mustIP("::2%foo")}, true},
+
+		{IPRange{mustIP("::1%foo"), mustIP("::2%bar")}, false}, // zones differ
+		{IPRange{IP{}, IP{}}, false},                           // zero values
+		{IPRange{mustIP("::2"), mustIP("::1")}, false},         // bad order
+		{IPRange{mustIP("1.2.3.4"), mustIP("::1")}, false},     // family mismatch
+	}
+	for _, tt := range tests {
+		got := tt.r.Valid()
+		if got != tt.want {
+			t.Errorf("range %v to %v Valid = %v; want %v", tt.r.From, tt.r.To, got, tt.want)
+		}
+	}
+}
+
 func TestIPRangePrefix(t *testing.T) {
 	tests := []struct {
 		r    IPRange


### PR DESCRIPTION
Also probably faster implementation (by accident).

Updates #84 (more remains)

Signed-off-by: Brad Fitzpatrick <brad@danga.com>