### PR TITLE
make IPPrefix.Contains return false for invalid receivers

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -1088,6 +1088,9 @@ func mask6(n uint8) uint128 {
 // A v6-mapped IPv6 address will not match an IPv4 prefix.
 // A zero-value IP will not match any prefix.
 func (p IPPrefix) Contains(ip IP) bool {
+	if !p.Valid() {
+		return false
+	}
 	if f1, f2 := p.IP.BitLen(), ip.BitLen(); f1 == 0 || f2 == 0 || f1 != f2 {
 		return false
 	}

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -2363,6 +2363,18 @@ func TestIPPrefixContains(t *testing.T) {
 		{mustIPPrefix("::1/127"), mustIP("::2"), false},
 		{mustIPPrefix("::1/128"), mustIP("::1"), true},
 		{mustIPPrefix("::1/127"), mustIP("::2"), false},
+		// invalid IP
+		{mustIPPrefix("::1/0"), IP{}, false},
+		{mustIPPrefix("1.2.3.4/0"), IP{}, false},
+		// invalid IPPrefix
+		{IPPrefix{mustIP("::1"), 129}, mustIP("::1"), false},
+		{IPPrefix{mustIP("1.2.3.4"), 33}, mustIP("1.2.3.4"), false},
+		{IPPrefix{IP{}, 0}, mustIP("1.2.3.4"), false},
+		{IPPrefix{IP{}, 32}, mustIP("1.2.3.4"), false},
+		{IPPrefix{IP{}, 128}, mustIP("::1"), false},
+		// wrong IP family
+		{mustIPPrefix("::1/0"), mustIP("1.2.3.4"), false},
+		{mustIPPrefix("1.2.3.4/0"), mustIP("::1"), false},
 	}
 	for _, tt := range tests {
 		got := tt.ipp.Contains(tt.ip)


### PR DESCRIPTION
Updates #101

(We need to review the rest of the IPPrefix methods before we can close it.)

Signed-off-by: Josh Bleecher Snyder <josharian@gmail.com>