### PR TITLE
Use IPPrefix.Valid in other IPPrefix methods.

### DIFF
--- a/inlining_test.go
+++ b/inlining_test.go
@@ -72,7 +72,7 @@ func TestInlining(t *testing.T) {
 		"IPPrefix.IsSingleIP",
 		"IPPrefix.IsZero",
 		"IPPrefix.Masked",
-		"IPPrefix.String",
+		"IPPrefix.MarshalText",
 		"IPPrefix.Valid",
 		"IPRange.prefixFrom128AndBits",
 		"IPRange.prefixFrom128AndBits-fm",


### PR DESCRIPTION
Adjust some tests to check behavior on invalid prefixes.

Signed-off-by: David Anderson <dave@natulte.net>