### PR TITLE
De-emphasize IPv4-mapped IPv6 handling, relegate it to stdlib compat.

### DIFF
--- a/inlining_test.go
+++ b/inlining_test.go
@@ -87,6 +87,7 @@ func TestInlining(t *testing.T) {
 		"uint128.and",
 		"uint128.or",
 		"uint128.xor",
+		"uint128.not",
 		"appendDecimal",
 		"appendHex",
 	} {

--- a/slow_test.go
+++ b/slow_test.go
@@ -82,7 +82,7 @@ func parseIPSlow(s string) (IP, error) {
 		ret[i*2+1] = b
 	}
 
-	return IPv6Raw(ret).WithZone(zone), nil
+	return IPFrom16(ret).WithZone(zone), nil
 }
 
 // normalizeIPv6Slow expands s, which is assumed to be an IPv6


### PR DESCRIPTION
Proposal implementation for #64, to de-emphasize auto-unmapping. Keep it for stdlib because stdlib makes ambiguous types, but otherwise constructors don't do unobvious things.