### PR TITLE
netaddr: change uint128.commonPrefixLen receiver name for consistency

### DIFF
--- a/uint128.go
+++ b/uint128.go
@@ -58,9 +58,9 @@ func u64CommonPrefixLen(a, b uint64) uint8 {
 	return uint8(bits.LeadingZeros64(a ^ b))
 }
 
-func (a uint128) commonPrefixLen(b uint128) (n uint8) {
-	if n = u64CommonPrefixLen(a.hi, b.hi); n == 64 {
-		n += u64CommonPrefixLen(a.lo, b.lo)
+func (u uint128) commonPrefixLen(v uint128) (n uint8) {
+	if n = u64CommonPrefixLen(u.hi, v.hi); n == 64 {
+		n += u64CommonPrefixLen(u.lo, v.lo)
 	}
 	return
 }


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>