### PR TITLE
netaddr: fix doc comment typo for IPPrefix.String

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -1138,7 +1138,7 @@ func (p *IPPrefix) UnmarshalText(text []byte) error {
 	return err
 }
 
-// Strings returns the CIDR notation of p: "<ip>/<bits>".
+// String returns the CIDR notation of p: "<ip>/<bits>".
 func (p IPPrefix) String() string {
 	if !p.Valid() {
 		return "invalid IP prefix"


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>