### PR TITLE
netaddr: add IP.StringExpanded to expand IPv6 address strings

### DIFF
--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -784,6 +784,41 @@ func TestLessCompare(t *testing.T) {
 	}
 }
 
+func TestIPStringExpanded(t *testing.T) {
+	tests := []struct {
+		ip IP
+		s  string
+	}{
+		{
+			ip: IP{},
+			s:  "invalid IP",
+		},
+		{
+			ip: mustIP("192.0.2.1"),
+			s:  "192.0.2.1",
+		},
+		{
+			ip: mustIP("2001:db8::1"),
+			s:  "2001:0db8:0000:0000:0000:0000:0000:0001",
+		},
+		{
+			ip: mustIP("2001:db8::1%eth0"),
+			s:  "2001:0db8:0000:0000:0000:0000:0000:0001%eth0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ip.String(), func(t *testing.T) {
+			want := tt.s
+			got := tt.ip.StringExpanded()
+
+			if got != want {
+				t.Fatalf("got %s, want %s", got, want)
+			}
+		})
+	}
+}
+
 func TestIPPrefixMasking(t *testing.T) {
 	type subtest struct {
 		ip   IP
@@ -1879,6 +1914,18 @@ func BenchmarkIPString(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				sinkString = ip.String()
+			}
+		})
+	}
+}
+
+func BenchmarkIPStringExpanded(b *testing.B) {
+	for _, test := range parseBenchInputs {
+		ip := MustParseIP(test.ip)
+		b.Run(test.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				sinkString = ip.StringExpanded()
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

Fixes #51. There's a bit of duplication between `IP.string6` and `IP.StringExpanded` but I was able to remove some logic regarding adding `::` compression so it seemed worth duplicating.