### PR TITLE
netaddr: return parseIPError for all ParseIP errors

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -137,7 +137,7 @@ func ParseIP(s string) (IP, error) {
 			return IP{}, parseIPError{in: s, msg: "missing IPv6 address"}
 		}
 	}
-	return IP{}, errors.New("unable to parse IP")
+	return IP{}, parseIPError{in: s, msg: "unable to parse IP"}
 }
 
 // MustParseIP calls ParseIP(s) and panics on error.

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -1284,6 +1284,9 @@ func TestParseIPError(t *testing.T) {
 			if err == nil {
 				t.Fatal("no error")
 			}
+			if _, ok := err.(parseIPError); !ok {
+				t.Errorf("error type is %T, want parseIPError", err)
+			}
 			if test.errstr == "" {
 				test.errstr = "unable to parse IP"
 			}


### PR DESCRIPTION
This ensures ParseIP errors always begin with `ParseIP(<input>): ` when
converted to strings.