### PR TITLE
.github: run GitHub actions on main branch pushes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@ name: Linux
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -3,7 +3,7 @@ name: staticcheck
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
Since renaming the branch to `main`, the GitHub actions didn't seem to
have run on pushes to that branch. Fix it by adjusting the branch name
in the workflows `on.push.branches`.