### PR TITLE
.github: add Go 1.16 to matrix

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # Oldest we support (1.12) and a latest couple:
-        go-version: [1.12, 1.14, 1.15]
+        go-version: [1.12, 1.15, 1.16]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Drop 1.14 and keep 1.12, 1.15.