### PR TITLE
Add IP.{Interface,Link}LocalMulticast methods

### DIFF
--- a/inlining_test.go
+++ b/inlining_test.go
@@ -56,6 +56,7 @@ func TestInlining(t *testing.T) {
 		"IP.Is6",
 		"IP.IsLoopback",
 		"IP.IsMulticast",
+		"IP.IsInterfaceLocalMulticast",
 		"IP.IsZero",
 		"IP.Less",
 		"IP.lessOrEq",

--- a/netaddr.go
+++ b/netaddr.go
@@ -564,6 +564,16 @@ func (ip IP) IsMulticast() bool {
 	return false // zero value
 }
 
+// IsInterfaceLocalMulticast reports whether ip is an IPv6 interface-local
+// multicast address. If ip is the zero value or an IPv4 address, it will return
+// false.
+func (ip IP) IsInterfaceLocalMulticast() bool {
+	if ip.Is6() {
+		return ip.v6u16(0)&0xff0f == 0xff01
+	}
+	return false // zero value
+}
+
 // Prefix applies a CIDR mask of leading bits to IP, producing an IPPrefix
 // of the specified length. If IP is the zero value, a zero-value IPPrefix and
 // a nil error are returned. If bits is larger than 32 for an IPv4 address or

--- a/netaddr.go
+++ b/netaddr.go
@@ -574,6 +574,18 @@ func (ip IP) IsInterfaceLocalMulticast() bool {
 	return false // zero value
 }
 
+// IsLinkLocalMulticast reports whether ip is a link-local multicast address.
+// If ip is the zero value, it will return false.
+func (ip IP) IsLinkLocalMulticast() bool {
+	if ip.Is4() {
+		return ip.v4(0) == 224 && ip.v4(1) == 0 && ip.v4(2) == 0
+	}
+	if ip.Is6() {
+		return ip.v6u16(0)&0xff0f == 0xff02
+	}
+	return false // zero value
+}
+
 // Prefix applies a CIDR mask of leading bits to IP, producing an IPPrefix
 // of the specified length. If IP is the zero value, a zero-value IPPrefix and
 // a nil error are returned. If bits is larger than 32 for an IPv4 address or

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -518,6 +518,7 @@ func TestIPProperties(t *testing.T) {
 		ip                      IP
 		multicast               bool
 		interfaceLocalMulticast bool
+		linkLocalMulticast      bool
 		linkLocalUnicast        bool
 		loopback                bool
 	}{
@@ -538,19 +539,22 @@ func TestIPProperties(t *testing.T) {
 			ip:   unicastZone6,
 		},
 		{
-			name:      "multicast v4Addr",
-			ip:        multicast4,
-			multicast: true,
+			name:               "multicast v4Addr",
+			ip:                 multicast4,
+			multicast:          true,
+			linkLocalMulticast: true,
 		},
 		{
-			name:      "multicast v6Addr",
-			ip:        multicast6,
-			multicast: true,
+			name:               "multicast v6Addr",
+			ip:                 multicast6,
+			multicast:          true,
+			linkLocalMulticast: true,
 		},
 		{
-			name:      "multicast v6AddrZone",
-			ip:        multicastZone6,
-			multicast: true,
+			name:               "multicast v6AddrZone",
+			ip:                 multicastZone6,
+			multicast:          true,
+			linkLocalMulticast: true,
 		},
 		{
 			name:             "link-local unicast v4Addr",
@@ -611,6 +615,11 @@ func TestIPProperties(t *testing.T) {
 			ilm := tt.ip.IsInterfaceLocalMulticast()
 			if ilm != tt.interfaceLocalMulticast {
 				t.Errorf("IsInterfaceLocalMulticast(%v) = %v; want %v", tt.ip, ilm, tt.interfaceLocalMulticast)
+			}
+
+			llm := tt.ip.IsLinkLocalMulticast()
+			if llm != tt.linkLocalMulticast {
+				t.Errorf("IsLinkLocalMulticast(%v) = %v; want %v", tt.ip, llm, tt.linkLocalMulticast)
 			}
 		})
 	}
@@ -2331,6 +2340,7 @@ func TestNoAllocs(t *testing.T) {
 	test("IP.IsLoopback", func() { sinkBool = MustParseIP("fe80::1").IsLoopback() })
 	test("IP.IsMulticast", func() { sinkBool = MustParseIP("fe80::1").IsMulticast() })
 	test("IP.IsInterfaceLocalMulticast", func() { sinkBool = MustParseIP("fe80::1").IsInterfaceLocalMulticast() })
+	test("IP.IsLinkLocalMulticast", func() { sinkBool = MustParseIP("fe80::1").IsLinkLocalMulticast() })
 	test("IP.Prefix/4", func() { sinkIPPrefix = panicPfx(MustParseIP("1.2.3.4").Prefix(20)) })
 	test("IP.Prefix/6", func() { sinkIPPrefix = panicPfx(MustParseIP("fe80::1").Prefix(64)) })
 	test("IP.As16", func() { sinkIP16 = MustParseIP("1.2.3.4").As16() })

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -508,14 +508,18 @@ func TestIPProperties(t *testing.T) {
 
 		loopback4 = mustIP("127.0.0.1")
 		loopback6 = mustIP("::1")
+
+		ilm6     = mustIP("ff01::1")
+		ilmZone6 = mustIP("ff01::1%eth0")
 	)
 
 	tests := []struct {
-		name             string
-		ip               IP
-		multicast        bool
-		linkLocalUnicast bool
-		loopback         bool
+		name                    string
+		ip                      IP
+		multicast               bool
+		interfaceLocalMulticast bool
+		linkLocalUnicast        bool
+		loopback                bool
 	}{
 		{
 			name: "nil",
@@ -573,6 +577,18 @@ func TestIPProperties(t *testing.T) {
 			ip:       loopback6,
 			loopback: true,
 		},
+		{
+			name:                    "interface-local multicast v6Addr",
+			ip:                      ilm6,
+			multicast:               true,
+			interfaceLocalMulticast: true,
+		},
+		{
+			name:                    "interface-local multicast v6AddrZone",
+			ip:                      ilmZone6,
+			multicast:               true,
+			interfaceLocalMulticast: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -590,6 +606,11 @@ func TestIPProperties(t *testing.T) {
 			lo := tt.ip.IsLoopback()
 			if lo != tt.loopback {
 				t.Errorf("IsLoopback(%v) = %v; want %v", tt.ip, lo, tt.loopback)
+			}
+
+			ilm := tt.ip.IsInterfaceLocalMulticast()
+			if ilm != tt.interfaceLocalMulticast {
+				t.Errorf("IsInterfaceLocalMulticast(%v) = %v; want %v", tt.ip, ilm, tt.interfaceLocalMulticast)
 			}
 		})
 	}
@@ -2309,6 +2330,7 @@ func TestNoAllocs(t *testing.T) {
 	test("IP.IsLinkLocalUnicast", func() { sinkBool = MustParseIP("fe80::1").IsLinkLocalUnicast() })
 	test("IP.IsLoopback", func() { sinkBool = MustParseIP("fe80::1").IsLoopback() })
 	test("IP.IsMulticast", func() { sinkBool = MustParseIP("fe80::1").IsMulticast() })
+	test("IP.IsInterfaceLocalMulticast", func() { sinkBool = MustParseIP("fe80::1").IsInterfaceLocalMulticast() })
 	test("IP.Prefix/4", func() { sinkIPPrefix = panicPfx(MustParseIP("1.2.3.4").Prefix(20)) })
 	test("IP.Prefix/6", func() { sinkIPPrefix = panicPfx(MustParseIP("fe80::1").Prefix(64)) })
 	test("IP.As16", func() { sinkIP16 = MustParseIP("1.2.3.4").As16() })


### PR DESCRIPTION
Corresponding to the respective standard library `net.IP` methods: [`net.IP.IsInterfaceLocalMulticast`](https://golang.org/pkg/net/#IP.IsInterfaceLocalMulticast) and [`net.IP.IsLinkLocalMulticast`](https://golang.org/pkg/net/#IP.IsLinkLocalMulticast).
