### PR TITLE
README: document stance on quality and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This is a package containing a new IP address type for Go.
 
 See its docs: https://pkg.go.dev/inet.af/netaddr
 
+## Status
+
+This package is mature, optimized, and used heavily in production at [Tailscale](https://tailscale.com).
+However, API stability is not yet guaranteed.
+
+netaddr is intended to be a core, low-level package.
+We take code review, testing, dependencies, and performance seriously, similar to Go's standard library or the golang.org/x repos.
+
 ## Motivation
 
 See https://tailscale.com/blog/netaddr-new-ip-type-for-go/ for a long
@@ -17,13 +25,6 @@ Other links:
 * https://github.com/golang/go/issues/18757 ("net: ParseIP should return an error, like other Parse functions")
 * https://github.com/golang/go/issues/37921 ("net: Unable to reliably distinguish IPv4-mapped-IPv6 addresses from regular IPv4 addresses")
 * merges net.IPAddr and net.IP (which the Go net package is a little torn between for legacy reasons)
-* ...
-* TODO: finish this list
-
-## Maturity
-
-This package is mature, optimized, and used heavily in production at [Tailscale](https://tailscale.com).
-However, API stability is not yet guaranteed.
 
 ## Testing
 


### PR DESCRIPTION
Rename "Maturity" section to "Status", move it to the top,
and indicate that we take quality and dependencies seriously.

Also, remove the TODO from the README.