### PR TITLE
netaddr: use value receiver for IP.Netmask

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -613,7 +613,7 @@ func (ip IP) Prefix(bits uint8) (IPPrefix, error) {
 // zero value, a zero-value IPPrefix and a nil error are returned. If the
 // netmask length is not 4 for IPv4 or 16 for IPv6, an error is
 // returned. If the netmask is non-contiguous, an error is returned.
-func (ip *IP) Netmask(mask []byte) (IPPrefix, error) {
+func (ip IP) Netmask(mask []byte) (IPPrefix, error) {
 	l := len(mask)
 
 	switch ip.z {


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

I believe this was an oversight when I merged #142 from @terinjokes. None of the other methods use pointer receivers except Unmarshal*.