### PR TITLE
netaddr: add IPv4Zero

### DIFF
--- a/inlining_test.go
+++ b/inlining_test.go
@@ -89,6 +89,7 @@ func TestInlining(t *testing.T) {
 		"IPRange.To",
 		"IPRange.From",
 		"IPv4",
+		"IPv4Zero",
 		"IPFrom4",
 		"IPv6LinkLocalAllNodes",
 		"IPv6Unspecified",

--- a/netaddr.go
+++ b/netaddr.go
@@ -93,6 +93,9 @@ func IPv4(a, b, c, d uint8) IP {
 	}
 }
 
+// IPv4Zero returns the IPv4 zero address 0.0.0.0.
+func IPv4Zero() IP { return IP{z: z4} }
+
 // IPv6Raw returns the IPv6 address given by the bytes in addr,
 // without an implicit Unmap call to unmap any v6-mapped IPv4
 // address.

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -697,6 +697,11 @@ func TestIPWellKnown(t *testing.T) {
 		std  net.IP
 	}{
 		{
+			name: "IPv4 zero",
+			ip:   IPv4Zero(),
+			std:  net.IPv4zero,
+		},
+		{
 			name: "IPv6 link-local all nodes",
 			ip:   IPv6LinkLocalAllNodes(),
 			std:  net.IPv6linklocalallnodes,
@@ -2719,6 +2724,7 @@ func TestNoAllocs(t *testing.T) {
 
 	// IP constructors
 	test("IPv4", func() { sinkIP = IPv4(1, 2, 3, 4) })
+	test("IPv4Zero", func() { sinkIP = IPv4Zero() })
 	test("IPFrom4", func() { sinkIP = IPFrom4([4]byte{1, 2, 3, 4}) })
 	test("IPv6", func() { sinkIP = IPv6Raw([16]byte{}) })
 	test("IPFrom16", func() { sinkIP = IPFrom16([16]byte{15: 1}) })


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

I need this for work, and it has symmetry with net.IPv4zero and netaddr.IPv6Unspecified.