### PR TITLE
improve IPSetBuilder error messages

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -45,7 +45,7 @@ func ExampleIP_properties() {
 	w.Flush()
 	// Output:
 	// String()           Zone()  IsZero()  Is4()  Is6()  Is4in6()
-	// invalid IP                 true      false  false  false
+	// zero IP                    true      false  false  false
 	// 192.0.2.3                  false     true   false  false
 	// 2001:db8::68               false     false  true   false
 	// 2001:db8::68%eth0  eth0    false     false  true   false

--- a/ipset.go
+++ b/ipset.go
@@ -183,6 +183,7 @@ func (s *IPSetBuilder) addError(msg string, args ...interface{}) {
 // Add adds ip to s.
 func (s *IPSetBuilder) Add(ip IP) {
 	if ip.IsZero() {
+		s.addError("Add of invalid IP %q", ip)
 		return
 	}
 	s.AddRange(IPRangeFrom(ip, ip))

--- a/ipset.go
+++ b/ipset.go
@@ -183,7 +183,7 @@ func (s *IPSetBuilder) addError(msg string, args ...interface{}) {
 // Add adds ip to s.
 func (s *IPSetBuilder) Add(ip IP) {
 	if ip.IsZero() {
-		s.addError("Add of invalid IP %q", ip)
+		s.addError("Add(IP{})")
 		return
 	}
 	s.AddRange(IPRangeFrom(ip, ip))
@@ -194,7 +194,7 @@ func (s *IPSetBuilder) AddPrefix(p IPPrefix) {
 	if r := p.Range(); r.IsValid() {
 		s.AddRange(r)
 	} else {
-		s.addError("AddPrefix of invalid prefix %q", p)
+		s.addError("AddPrefix(%v/%v)", p.IP(), p.Bits())
 	}
 }
 
@@ -202,7 +202,7 @@ func (s *IPSetBuilder) AddPrefix(p IPPrefix) {
 // If r is not Valid, AddRange does nothing.
 func (s *IPSetBuilder) AddRange(r IPRange) {
 	if !r.IsValid() {
-		s.addError("AddRange of invalid range %q", r)
+		s.addError("AddRange(%v-%v)", r.From(), r.To())
 		return
 	}
 	// If there are any removals (s.out), then we need to compact the set
@@ -226,7 +226,7 @@ func (s *IPSetBuilder) AddSet(b *IPSet) {
 // Remove removes ip from s.
 func (s *IPSetBuilder) Remove(ip IP) {
 	if ip.IsZero() {
-		s.addError("ignored Remove of zero IP")
+		s.addError("Remove(IP{})")
 	} else {
 		s.RemoveRange(IPRangeFrom(ip, ip))
 	}
@@ -237,7 +237,7 @@ func (s *IPSetBuilder) RemovePrefix(p IPPrefix) {
 	if r := p.Range(); r.IsValid() {
 		s.RemoveRange(r)
 	} else {
-		s.addError("RemovePrefix of invalid prefix %q", p)
+		s.addError("RemovePrefix(%v/%v)", p.IP(), p.Bits())
 	}
 }
 
@@ -246,7 +246,7 @@ func (s *IPSetBuilder) RemoveRange(r IPRange) {
 	if r.IsValid() {
 		s.out = append(s.out, r)
 	} else {
-		s.addError("RemoveRange of invalid range %q", r)
+		s.addError("RemoveRange(%v-%v)", r.From(), r.To())
 	}
 }
 

--- a/netaddr.go
+++ b/netaddr.go
@@ -821,7 +821,7 @@ func (ip IP) Prior() IP {
 func (ip IP) String() string {
 	switch ip.z {
 	case z0:
-		return "invalid IP"
+		return "zero IP"
 	case z4:
 		return ip.string4()
 	default:

--- a/netaddr.go
+++ b/netaddr.go
@@ -1540,6 +1540,9 @@ func (p *IPPrefix) UnmarshalText(text []byte) error {
 
 // String returns the CIDR notation of p: "<ip>/<bits>".
 func (p IPPrefix) String() string {
+	if p.IsZero() {
+		return "zero IPPrefix"
+	}
 	if !p.IsValid() {
 		return "invalid IPPrefix"
 	}

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -2922,7 +2922,7 @@ func TestIPPrefixString(t *testing.T) {
 		ipp  IPPrefix
 		want string
 	}{
-		{IPPrefix{}, "invalid IPPrefix"},
+		{IPPrefix{}, "zero IPPrefix"},
 		{IPPrefixFrom(IP{}, 8), "invalid IPPrefix"},
 		{IPPrefixFrom(MustParseIP("1.2.3.4"), 88), "invalid IPPrefix"},
 	}

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -861,7 +861,7 @@ func TestLessCompare(t *testing.T) {
 	}
 	sort.Slice(values, func(i, j int) bool { return values[i].Less(values[j]) })
 	got := fmt.Sprintf("%s", values)
-	want := `[invalid IP 1.2.3.4 8.8.8.8 ::1 ::1%foo ::2]`
+	want := `[zero IP 1.2.3.4 8.8.8.8 ::1 ::1%foo ::2]`
 	if got != want {
 		t.Errorf("unexpected sort\n got: %s\nwant: %s\n", got, want)
 	}
@@ -874,7 +874,7 @@ func TestIPStringExpanded(t *testing.T) {
 	}{
 		{
 			ip: IP{},
-			s:  "invalid IP",
+			s:  "zero IP",
 		},
 		{
 			ip: mustIP("192.0.2.1"),

--- a/stackerr_test.go
+++ b/stackerr_test.go
@@ -18,12 +18,12 @@ import (
 func TestStacktraceErr(t *testing.T) {
 	b := new(netaddr.IPSetBuilder)
 //line ipp.go:1
-	b.AddPrefix(netaddr.IPPrefix{})
+	b.AddPrefix(netaddr.IPPrefixFrom(netaddr.IPv4(1,2,3,4), 33))
 //line r.go:2
 	b.AddRange(netaddr.IPRange{})
 	_, err := b.IPSet()
 	got := err.Error()
-	for _, want := range []string{"ipp.go:1", "r.go:2"} {
+	for _, want := range []string{"ipp.go:1", "r.go:2", "33"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("error should contain %q, got %q", want, got)
 		}

--- a/stackerr_test.go
+++ b/stackerr_test.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Inet.Af AUTHORS. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package netaddr_test
+
+import (
+	"strings"
+	"testing"
+
+	"inet.af/netaddr"
+)
+
+// The tests for stacktrace errors is in its own file,
+// so that the line number munging that we do doesn't
+// break line numbers for other tests.
+
+func TestStacktraceErr(t *testing.T) {
+	b := new(netaddr.IPSetBuilder)
+//line ipp.go:1
+	b.AddPrefix(netaddr.IPPrefix{})
+//line r.go:2
+	b.AddRange(netaddr.IPRange{})
+	_, err := b.IPSet()
+	got := err.Error()
+	for _, want := range []string{"ipp.go:1", "r.go:2"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error should contain %q, got %q", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Please review commit-by-commit, but note that some later commits refine the earlier ones. (I can squash if desired, but I thought the evolution might be useful and easier to review than a mass rewrite.)

The overarching goal is to make the error messages from IPSetBuilder more useful and actionable.

I'm not particular about any of the details. I tried to make the error messages single-line, because that is my preference (for logging, etc.), but a more verbose multi-line form might be more useful.
