### PR TITLE
netaddr: add IP.IsGlobalUnicast

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -117,6 +117,46 @@ func ExampleIP_IsZero() {
 	// (::).IsZero() -> false
 }
 
+func ExampleIP_IsGlobalUnicast() {
+	var (
+		zeroIP netaddr.IP
+
+		ipv4AllZeroes = netaddr.MustParseIP("0.0.0.0")
+		ipv4          = netaddr.MustParseIP("192.0.2.3")
+
+		ipv6AllZeroes  = netaddr.MustParseIP("::")
+		ipv6LinkLocal  = netaddr.MustParseIP("fe80::1")
+		ipv6           = netaddr.MustParseIP("2001:db8::68")
+		ipv6Unassigned = netaddr.MustParseIP("4000::1")
+		ip4in6         = netaddr.MustParseIP("::ffff:192.0.2.3")
+	)
+
+	fmt.Printf("IP{}.IsGlobalUnicast() -> %v\n", zeroIP.IsGlobalUnicast())
+
+	ips := []netaddr.IP{
+		ipv4AllZeroes,
+		ipv4,
+		ipv6AllZeroes,
+		ipv6LinkLocal,
+		ipv6,
+		ipv6Unassigned,
+		ip4in6,
+	}
+
+	for _, ip := range ips {
+		fmt.Printf("(%v).IsGlobalUnicast() -> %v\n", ip, ip.IsGlobalUnicast())
+	}
+	// Output:
+	// IP{}.IsGlobalUnicast() -> false
+	// (0.0.0.0).IsGlobalUnicast() -> false
+	// (192.0.2.3).IsGlobalUnicast() -> true
+	// (::).IsGlobalUnicast() -> false
+	// (fe80::1).IsGlobalUnicast() -> false
+	// (2001:db8::68).IsGlobalUnicast() -> true
+	// (4000::1).IsGlobalUnicast() -> true
+	// (::ffff:c000:203).IsGlobalUnicast() -> true
+}
+
 func ExampleIP_String() {
 	ipv4 := netaddr.MustParseIP("192.0.2.3")
 	ipv6 := netaddr.MustParseIP("2001:db8::68")

--- a/netaddr.go
+++ b/netaddr.go
@@ -632,6 +632,33 @@ func (ip IP) IsLinkLocalMulticast() bool {
 	return false // zero value
 }
 
+// IsGlobalUnicast reports whether ip is a global unicast address.
+//
+// It returns true for IPv6 addresses which fall outside of the current
+// IANA-allocated 2000::/3 global unicast space, with the exception of the
+// link-local address space. It also returns true even if ip is in the IPv4
+// private address space or IPv6 unique local address space. If ip is the zero
+// value, it will return false.
+//
+// For reference, see RFC 1122, RFC 4291, and RFC 4632.
+func (ip IP) IsGlobalUnicast() bool {
+	if ip.z == z0 {
+		// Invalid or zero-value.
+		return false
+	}
+
+	// Match the stdlib's IsGlobalUnicast logic. Notably private IPv4 addresses
+	// and ULA IPv6 addresses are still considered "global unicast".
+	if ip.Is4() && (ip == IPv4(0, 0, 0, 0) || ip == IPv4(255, 255, 255, 255)) {
+		return false
+	}
+
+	return ip != IPv6Unspecified() &&
+		!ip.IsLoopback() &&
+		!ip.IsMulticast() &&
+		!ip.IsLinkLocalUnicast()
+}
+
 // Prefix applies a CIDR mask of leading bits to IP, producing an IPPrefix
 // of the specified length. If IP is the zero value, a zero-value IPPrefix and
 // a nil error are returned. If bits is larger than 32 for an IPv4 address or


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

Another helper I need for CoreRAD. I'd also like to add functions for IPv6 ULA detection, so maybe we can mirror Go 1.17's https://tip.golang.org/pkg/net/#IP.IsPrivate in a follow-up PR.

Notably the new function matches the stdlib logic but since we don't have IPv4zero (pending #187) or IPv4 broadcast, we just declare those inline. It's probably not a big deal though.

I know this has grown organically, but as a matter of tidying, I arrange some table test fields alphabetically and adjusted the comparisons to match. If this is undesirable or noisy, I'm happy to revert and just keep appending fields.

