### PR TITLE
netaddr: add IP.IsPrivate

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -157,6 +157,37 @@ func ExampleIP_IsGlobalUnicast() {
 	// (::ffff:c000:203).IsGlobalUnicast() -> true
 }
 
+func ExampleIP_IsPrivate() {
+	var (
+		zeroIP netaddr.IP
+
+		ipv4        = netaddr.MustParseIP("192.0.2.3")
+		ipv4Private = netaddr.MustParseIP("192.168.1.1")
+
+		ipv6        = netaddr.MustParseIP("2001:db8::68")
+		ipv6Private = netaddr.MustParseIP("fd00::1")
+	)
+
+	fmt.Printf("IP{}.IsPrivate() -> %v\n", zeroIP.IsPrivate())
+
+	ips := []netaddr.IP{
+		ipv4,
+		ipv4Private,
+		ipv6,
+		ipv6Private,
+	}
+
+	for _, ip := range ips {
+		fmt.Printf("(%v).IsPrivate() -> %v\n", ip, ip.IsPrivate())
+	}
+	// Output:
+	// IP{}.IsPrivate() -> false
+	// (192.0.2.3).IsPrivate() -> false
+	// (192.168.1.1).IsPrivate() -> true
+	// (2001:db8::68).IsPrivate() -> false
+	// (fd00::1).IsPrivate() -> true
+}
+
 func ExampleIP_IsUnspecified() {
 	var zeroIP netaddr.IP
 	ipv4AllZeroes := netaddr.MustParseIP("0.0.0.0")

--- a/netaddr.go
+++ b/netaddr.go
@@ -666,6 +666,29 @@ func (ip IP) IsGlobalUnicast() bool {
 		!ip.IsLinkLocalUnicast()
 }
 
+// IsPrivate reports whether ip is a private address, according to RFC 1918
+// (IPv4 addresses) and RFC 4193 (IPv6 addresses). That is, it reports whether
+// ip is in 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, or fc00::/7. This is the
+// same as the standard library's net.IP.IsPrivate.
+func (ip IP) IsPrivate() bool {
+	// Match the stdlib's IsPrivate logic.
+	if ip.Is4() {
+		// RFC 1918 allocates 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16 as
+		// private IPv4 address subnets.
+		return ip.v4(0) == 10 ||
+			(ip.v4(0) == 172 && ip.v4(1)&0xf0 == 16) ||
+			(ip.v4(0) == 192 && ip.v4(1) == 168)
+	}
+
+	if ip.Is6() {
+		// RFC 4193 allocates fc00::/7 as the unique local unicast IPv6 address
+		// subnet.
+		return ip.v6(0)&0xfe == 0xfc
+	}
+
+	return false // zero value
+}
+
 // IsUnspecified reports whether ip is an unspecified address, either the IPv4
 // address "0.0.0.0" or the IPv6 address "::".
 //

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -573,6 +573,11 @@ func TestIPProperties(t *testing.T) {
 		ilm6     = mustIP("ff01::1")
 		ilmZone6 = mustIP("ff01::1%eth0")
 
+		private4a = mustIP("10.0.0.1")
+		private4b = mustIP("172.16.0.1")
+		private4c = mustIP("192.168.1.1")
+		private6  = mustIP("fd00::1")
+
 		unspecified4 = IPv4(0, 0, 0, 0)
 		unspecified6 = IPv6Unspecified()
 	)
@@ -586,6 +591,7 @@ func TestIPProperties(t *testing.T) {
 		linkLocalUnicast        bool
 		loopback                bool
 		multicast               bool
+		private                 bool
 		unspecified             bool
 	}{
 		{
@@ -673,6 +679,30 @@ func TestIPProperties(t *testing.T) {
 			multicast:               true,
 		},
 		{
+			name:          "private v4Addr 10/8",
+			ip:            private4a,
+			globalUnicast: true,
+			private:       true,
+		},
+		{
+			name:          "private v4Addr 172.16/12",
+			ip:            private4b,
+			globalUnicast: true,
+			private:       true,
+		},
+		{
+			name:          "private v4Addr 192.168/16",
+			ip:            private4c,
+			globalUnicast: true,
+			private:       true,
+		},
+		{
+			name:          "private v6Addr",
+			ip:            private6,
+			globalUnicast: true,
+			private:       true,
+		},
+		{
 			name:        "unspecified v4Addr",
 			ip:          unspecified4,
 			unspecified: true,
@@ -714,6 +744,11 @@ func TestIPProperties(t *testing.T) {
 			multicast := tt.ip.IsMulticast()
 			if multicast != tt.multicast {
 				t.Errorf("IsMulticast(%v) = %v; want %v", tt.ip, multicast, tt.multicast)
+			}
+
+			private := tt.ip.IsPrivate()
+			if private != tt.private {
+				t.Errorf("IsPrivate(%v) = %v; want %v", tt.ip, private, tt.private)
 			}
 
 			unspecified := tt.ip.IsUnspecified()
@@ -2795,6 +2830,7 @@ func TestNoAllocs(t *testing.T) {
 	test("IP.IsLinkLocalUnicast", func() { sinkBool = MustParseIP("fe80::1").IsLinkLocalUnicast() })
 	test("IP.IsLoopback", func() { sinkBool = MustParseIP("fe80::1").IsLoopback() })
 	test("IP.IsMulticast", func() { sinkBool = MustParseIP("fe80::1").IsMulticast() })
+	test("IP.IsPrivate", func() { sinkBool = MustParseIP("fd00::1").IsPrivate() })
 	test("IP.IsUnspecified", func() { sinkBool = IPv6Unspecified().IsUnspecified() })
 	test("IP.Prefix/4", func() { sinkIPPrefix = panicPfx(MustParseIP("1.2.3.4").Prefix(20)) })
 	test("IP.Prefix/6", func() { sinkIPPrefix = panicPfx(MustParseIP("fe80::1").Prefix(64)) })


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

This is probably the last method I need for a bit. Notably this mirrors the upcoming https://tip.golang.org/pkg/net/#IP.IsPrivate for Go 1.17.