### PR TITLE
netaddr: fix fuzz build

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -129,13 +129,8 @@ func checkBinaryMarshaller(x encoding.BinaryMarshaler) {
 	}
 }
 
-type appendMarshaller interface {
-	encoding.TextMarshaler
-	AppendTo([]byte) []byte
-}
-
 // checkTextMarshalMatchesAppendTo checks that x's MarshalText matches x's AppendTo.
-func checkTextMarshalMatchesAppendTo(x appendMarshaller) {
+func checkTextMarshalMatchesAppendTo(x appendMarshaler) {
 	buf, err := x.MarshalText()
 	if err != nil {
 		panic(err)
@@ -189,7 +184,7 @@ func checkEncoding(x interface{}) {
 	if bm, ok := x.(encoding.BinaryMarshaler); ok {
 		checkBinaryMarshaller(bm)
 	}
-	if am, ok := x.(appendMarshaller); ok {
+	if am, ok := x.(appendMarshaler); ok {
 		checkTextMarshalMatchesAppendTo(am)
 	}
 }

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -1799,14 +1799,14 @@ func TestIPPortMarshalUnmarshal(t *testing.T) {
 	}
 }
 
-type appendMarshaller interface {
+type appendMarshaler interface {
 	encoding.TextMarshaler
 	AppendTo([]byte) []byte
 }
 
 // testAppendToMarshal tests that x's AppendTo and MarshalText methods yield the same results.
 // x's MarshalText method must not return an error.
-func testAppendToMarshal(t *testing.T, x appendMarshaller) {
+func testAppendToMarshal(t *testing.T, x appendMarshaler) {
 	t.Helper()
 	m, err := x.MarshalText()
 	if err != nil {


### PR DESCRIPTION
The appendMarshaller type is declared in both fuzz.go and netaddr_test.go,
which causes the fuzz tests to fail to build. Use the one in netaddr_test.go.
While we're at it, rename it to appendMarshaler.