### PR TITLE
Update CI to Go 1.17, check `gofmt` in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # Oldest we support (1.12) and a latest couple:
-        go-version: [1.12, 1.15, 1.16]
+        go-version: [1.12, 1.16, 1.17]
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Check Go modules
-      if: matrix.go-version == '1.16'
+      if: matrix.go-version == '1.17'
       run: |
         go mod tidy
         git diff --exit-code

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,5 +32,9 @@ jobs:
         go mod tidy
         git diff --exit-code
 
+    - name: Check formatting
+      if: matrix.go-version == '1.17'
+      run: diff -u <(echo -n) <(gofmt -d .)
+
     - name: Run tests on linux
       run: go test ./...

--- a/fuzz.go
+++ b/fuzz.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build gofuzz
 // +build gofuzz
 
 package netaddr

--- a/stackerr_test.go
+++ b/stackerr_test.go
@@ -18,7 +18,7 @@ import (
 func TestStacktraceErr(t *testing.T) {
 	b := new(netaddr.IPSetBuilder)
 //line ipp.go:1
-	b.AddPrefix(netaddr.IPPrefixFrom(netaddr.IPv4(1,2,3,4), 33))
+	b.AddPrefix(netaddr.IPPrefixFrom(netaddr.IPv4(1, 2, 3, 4), 33))
 //line r.go:2
 	b.AddRange(netaddr.IPRange{})
 	_, err := b.IPSet()

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
* `gofmt` with Go 1.17 to add `//go:build` tags
* Add Go 1.17 to test matrix
* Check formatting in CI