### PR TITLE
Add dotted decimal output for mapped addr

### DIFF
--- a/netaddr.go
+++ b/netaddr.go
@@ -953,6 +953,28 @@ func (ip IP) appendTo6(ret []byte) []byte {
 	return ret
 }
 
+// StringMapped is like String but IPv4 mapped IPv6 addresses the IPv4 part is
+// written as dotted decimal.
+// For example, "::ffff:c000:0202" becomes "::ffff:192.0.2.2".
+func (ip IP) StringMapped() string {
+	if !ip.Is4in6() {
+		return ip.String()
+	}
+
+	const size = len("::ffff:255.255.255.255")
+	ret := make([]byte, 0, size)
+	ret = append(ret, "::ffff:"...)
+	for i := uint8(12); i < 16; i++ {
+		if i > 12 {
+			ret = append(ret, '.')
+		}
+
+		ret = append(ret, strconv.Itoa(int(ip.v6(i)))...)
+	}
+
+	return string(ret)
+}
+
 // StringExpanded is like String but IPv6 addresses are expanded with leading
 // zeroes and no "::" compression. For example, "2001:db8::1" becomes
 // "2001:0db8:0000:0000:0000:0000:0000:0001".

--- a/netaddr_test.go
+++ b/netaddr_test.go
@@ -902,6 +902,45 @@ func TestIPStringExpanded(t *testing.T) {
 	}
 }
 
+func TestIPStringMapped(t *testing.T) {
+	tests := []struct {
+		ip IP
+		s  string
+	}{
+		{
+			ip: IP{},
+			s:  "zero IP",
+		},
+		{
+			ip: mustIP("192.0.2.1"),
+			s:  "192.0.2.1",
+		},
+		{
+			ip: mustIP("2001:db8::1"),
+			s:  "2001:db8::1",
+		},
+		{
+			ip: mustIP("2001:db8::1%eth0"),
+			s:  "2001:db8::1%eth0",
+		},
+		{
+			ip: mustIP("::ffff:c000:0200"),
+			s:  "::ffff:192.0.2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ip.String(), func(t *testing.T) {
+			want := tt.s
+			got := tt.ip.StringMapped()
+
+			if got != want {
+				t.Fatalf("got %s, want %s", got, want)
+			}
+		})
+	}
+}
+
 func TestIPPrefixMasking(t *testing.T) {
 	type subtest struct {
 		ip   IP


### PR DESCRIPTION
For IPv4 mapped IPv6 addresses it is commont to see the IPv4 part of the
address as dotted decmal after a prefix of `::ffff:` making
`::ffff:c000:0202` be printed as `::ffff:192.0.2.2`.

This commit implements a method that prints this format for mapped
addresses, and uses `String()` for all non mapped addresses.